### PR TITLE
Implementa fluxo de cadastro para usuários receptores (pacientes)

### DIFF
--- a/mobile/app/register/receptor.tsx
+++ b/mobile/app/register/receptor.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { ReceptorRegistrationScreen } from '@/screens/ReceptorRegistration';
+
+export default function ReceptorRegistration() {
+  return <ReceptorRegistrationScreen />;
+}

--- a/mobile/screens/ReceptorRegistration/index.tsx
+++ b/mobile/screens/ReceptorRegistration/index.tsx
@@ -1,0 +1,321 @@
+import React, { useRef, useState } from 'react';
+import {
+  View,
+  TextInput,
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Input } from '@/components/Input';
+import PrimaryButton from '@/components/PrimaryButton';
+import ArrowBackButton from '@/components/ArrowBackButton';
+import { Title } from '@/components/Title';
+import { Caption } from '@/components/Caption';
+import { useFeatureForm } from '@/hooks/useFeatureForm';
+import { useReceptorRegistrationStore } from '@/stores/receptorRegistrationStore';
+import {
+  receptorRegistrationSchema,
+  ReceptorRegistrationFormData,
+} from '@/utils/validation/receptorValidation';
+import { Colors } from '@/constants/Colors';
+import { styles } from './styles';
+import { Ionicons } from '@expo/vector-icons';
+
+export function ReceptorRegistrationScreen() {
+  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirmation, setShowPasswordConfirmation] = useState(false);
+
+  const {
+    updateFormData,
+    submitRegistration,
+    isLoading,
+    error,
+    validationErrors,
+    clearErrors,
+    resetForm,
+  } = useReceptorRegistrationStore();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    setError,
+    watch,
+    setValue,
+  } = useFeatureForm<ReceptorRegistrationFormData>({
+    schema: receptorRegistrationSchema,
+    defaultValues: {
+      name: '',
+      email: '',
+      cpf: '',
+      phone_number: '',
+      password: '',
+      password_confirmation: '',
+      terms_accepted: false,
+    },
+  });
+
+  const termsAccepted = watch('terms_accepted');
+
+  // Refs para navegação entre inputs
+  const emailRef = useRef<TextInput>(null);
+  const cpfRef = useRef<TextInput>(null);
+  const phoneRef = useRef<TextInput>(null);
+  const passwordRef = useRef<TextInput>(null);
+  const passwordConfirmationRef = useRef<TextInput>(null);
+
+  // Função para aplicar máscara de CPF
+  const formatCPF = (value: string): string => {
+    const numbers = value.replace(/\D/g, '');
+    if (numbers.length <= 3) return numbers;
+    if (numbers.length <= 6) return `${numbers.slice(0, 3)}.${numbers.slice(3)}`;
+    if (numbers.length <= 9)
+      return `${numbers.slice(0, 3)}.${numbers.slice(3, 6)}.${numbers.slice(6)}`;
+    return `${numbers.slice(0, 3)}.${numbers.slice(3, 6)}.${numbers.slice(6, 9)}-${numbers.slice(9, 11)}`;
+  };
+
+  // Função para aplicar máscara de telefone
+  const formatPhone = (value: string): string => {
+    const numbers = value.replace(/\D/g, '');
+    if (numbers.length <= 2) return numbers;
+    if (numbers.length <= 7) return `(${numbers.slice(0, 2)}) ${numbers.slice(2)}`;
+    return `(${numbers.slice(0, 2)}) ${numbers.slice(2, 7)}-${numbers.slice(7, 11)}`;
+  };
+
+  const handleGoBack = () => {
+    resetForm();
+    clearErrors();
+    router.push('/register');
+  };
+
+  const handleTermsToggle = () => {
+    setValue('terms_accepted', !termsAccepted);
+  };
+
+  const onSubmit = async (data: ReceptorRegistrationFormData) => {
+    // Atualiza a store com os dados do formulário
+    updateFormData({
+      name: data.name,
+      email: data.email,
+      cpf: data.cpf,
+      phone_number: data.phone_number,
+      password: data.password,
+      password_confirmation: data.password_confirmation,
+      terms_accepted: data.terms_accepted,
+    });
+
+    const success = await submitRegistration();
+
+    if (!success && validationErrors) {
+      // Mapeia erros do backend para o formulário
+      Object.keys(validationErrors).forEach((key) => {
+        const fieldKey = key as keyof ReceptorRegistrationFormData;
+        if (validationErrors[key]?.[0]) {
+          setError(fieldKey, { message: validationErrors[key][0] });
+        }
+      });
+    }
+
+    if (success) {
+      router.replace('/(auth)/dashboard');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.yellow_green_400} />
+          <Text style={styles.loadingText}>Criando sua conta...</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ArrowBackButton style={{ marginTop: 56 }} onPress={handleGoBack} />
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ flexGrow: 1 }}
+      >
+        <View style={styles.textContainer}>
+          <Title>Olá, paciente!</Title>
+          <Caption>Preencha seus dados para criar sua conta</Caption>
+        </View>
+
+        {error && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        <View style={styles.inputContainer}>
+          <Input
+            formProps={{
+              name: 'name',
+              control: control,
+            }}
+            inputProps={{
+              returnKeyType: 'next',
+              placeholder: 'Nome Completo',
+              autoCapitalize: 'words',
+              onSubmitEditing: () => emailRef.current?.focus(),
+            }}
+            error={errors.name?.message}
+          />
+
+          <Input
+            ref={emailRef}
+            formProps={{
+              name: 'email',
+              control: control,
+            }}
+            inputProps={{
+              returnKeyType: 'next',
+              placeholder: 'Email',
+              keyboardType: 'email-address',
+              autoCapitalize: 'none',
+              autoComplete: 'email',
+              onSubmitEditing: () => cpfRef.current?.focus(),
+            }}
+            error={errors.email?.message}
+          />
+
+          <Input
+            ref={cpfRef}
+            formProps={{
+              name: 'cpf',
+              control: control,
+              rules: {
+                onChange: (e: any) => {
+                  const formatted = formatCPF(e.target.value);
+                  setValue('cpf', formatted);
+                },
+              },
+            }}
+            inputProps={{
+              returnKeyType: 'next',
+              placeholder: 'CPF (000.000.000-00)',
+              keyboardType: 'numeric',
+              maxLength: 14,
+              onSubmitEditing: () => phoneRef.current?.focus(),
+            }}
+            error={errors.cpf?.message}
+          />
+
+          <Input
+            ref={phoneRef}
+            formProps={{
+              name: 'phone_number',
+              control: control,
+              rules: {
+                onChange: (e: any) => {
+                  const formatted = formatPhone(e.target.value);
+                  setValue('phone_number', formatted);
+                },
+              },
+            }}
+            inputProps={{
+              returnKeyType: 'next',
+              placeholder: 'Telefone (00) 00000-0000',
+              keyboardType: 'phone-pad',
+              maxLength: 15,
+              onSubmitEditing: () => passwordRef.current?.focus(),
+            }}
+            error={errors.phone_number?.message}
+          />
+
+          <View style={styles.passwordContainer}>
+            <Input
+              ref={passwordRef}
+              formProps={{
+                name: 'password',
+                control: control,
+              }}
+              inputProps={{
+                returnKeyType: 'next',
+                placeholder: 'Senha (mínimo 8 caracteres)',
+                secureTextEntry: !showPassword,
+                autoCapitalize: 'none',
+                onSubmitEditing: () => passwordConfirmationRef.current?.focus(),
+              }}
+              error={errors.password?.message}
+            />
+            <TouchableOpacity
+              style={styles.eyeButton}
+              onPress={() => setShowPassword(!showPassword)}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Ionicons
+                name={showPassword ? 'eye-off-outline' : 'eye-outline'}
+                size={24}
+                color={Colors.yellow_green_600}
+              />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.passwordContainer}>
+            <Input
+              ref={passwordConfirmationRef}
+              formProps={{
+                name: 'password_confirmation',
+                control: control,
+              }}
+              inputProps={{
+                returnKeyType: 'done',
+                placeholder: 'Confirmar Senha',
+                secureTextEntry: !showPasswordConfirmation,
+                autoCapitalize: 'none',
+                onSubmitEditing: () => handleSubmit(onSubmit)(),
+              }}
+              error={errors.password_confirmation?.message}
+            />
+            <TouchableOpacity
+              style={styles.eyeButton}
+              onPress={() => setShowPasswordConfirmation(!showPasswordConfirmation)}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Ionicons
+                name={showPasswordConfirmation ? 'eye-off-outline' : 'eye-outline'}
+                size={24}
+                color={Colors.yellow_green_600}
+              />
+            </TouchableOpacity>
+          </View>
+
+          <TouchableOpacity
+            style={styles.termsContainer}
+            onPress={handleTermsToggle}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.checkbox, termsAccepted && styles.checkboxChecked]}>
+              {termsAccepted && <Ionicons name="checkmark" size={16} color="#FFFFFF" />}
+            </View>
+            <Text style={styles.termsText}>
+              Li e aceito os <Text style={styles.termsLink}>Termos de Uso</Text> e a{' '}
+              <Text style={styles.termsLink}>Política de Privacidade</Text>
+            </Text>
+          </TouchableOpacity>
+          {errors.terms_accepted?.message && (
+            <Text style={styles.termsError}>{errors.terms_accepted.message}</Text>
+          )}
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <PrimaryButton onPress={() => handleSubmit(onSubmit)()} label="Criar Conta" />
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/mobile/screens/ReceptorRegistration/styles.ts
+++ b/mobile/screens/ReceptorRegistration/styles.ts
@@ -1,0 +1,109 @@
+import { StyleSheet } from 'react-native';
+import { Colors } from '@/constants/Colors';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.yellow_green_50,
+    paddingHorizontal: 20,
+  },
+
+  textContainer: {
+    textAlign: 'left',
+    marginTop: 28,
+    marginBottom: 24,
+    gap: 4,
+  },
+
+  inputContainer: {
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+
+  passwordContainer: {
+    position: 'relative',
+    width: '100%',
+  },
+
+  eyeButton: {
+    position: 'absolute',
+    right: 16,
+    top: 12,
+    zIndex: 1,
+  },
+
+  errorContainer: {
+    backgroundColor: '#FEE2E2',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+
+  errorText: {
+    color: '#DC2626',
+    textAlign: 'center',
+    fontSize: 14,
+  },
+
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  loadingText: {
+    marginTop: 16,
+    color: Colors.yellow_green_950,
+    fontSize: 16,
+  },
+
+  buttonContainer: {
+    marginTop: 'auto',
+    alignItems: 'center',
+    marginBottom: 52,
+  },
+
+  termsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 16,
+    paddingHorizontal: 4,
+  },
+
+  checkbox: {
+    marginRight: 12,
+    width: 24,
+    height: 24,
+    borderRadius: 6,
+    borderWidth: 2,
+    borderColor: Colors.yellow_green_400,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+
+  checkboxChecked: {
+    backgroundColor: Colors.yellow_green_400,
+    borderColor: Colors.yellow_green_400,
+  },
+
+  termsText: {
+    flex: 1,
+    fontSize: 14,
+    color: Colors.yellow_green_800,
+    lineHeight: 20,
+  },
+
+  termsLink: {
+    color: Colors.yellow_green_600,
+    textDecorationLine: 'underline',
+  },
+
+  termsError: {
+    color: '#DC2626',
+    fontSize: 12,
+    marginTop: -8,
+    marginBottom: 8,
+    paddingHorizontal: 4,
+  },
+});

--- a/mobile/screens/RegisterScreen/index.tsx
+++ b/mobile/screens/RegisterScreen/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouter } from 'expo-router';
+import { useRouter, Href } from 'expo-router';
 import { View, Image, ImageBackground } from 'react-native';
 import PrimaryButton from '@/components/PrimaryButton';
 import { styles } from './styles';
@@ -25,7 +25,10 @@ export function RegisterScreen() {
         <View style={styles.choiceContainer}>
           <View style={styles.imageContainer}>
             <Image source={require('@/assets/images/Paciente.png')} style={styles.patientImage} />
-            <PrimaryButton onPress={() => console.log('Paciente')} label="Paciente" />
+            <PrimaryButton
+              onPress={() => router.push('/register/receptor' as Href)}
+              label="Paciente"
+            />
           </View>
 
           <View style={styles.imageContainer}>

--- a/mobile/services/receptorService.ts
+++ b/mobile/services/receptorService.ts
@@ -1,0 +1,37 @@
+import api from './api';
+
+export interface ReceptorRegistrationData {
+  name: string;
+  email: string;
+  cpf: string;
+  phone_number: string;
+  password: string;
+  password_confirmation: string;
+  device_name: string;
+  terms_accepted: boolean;
+}
+
+export interface ReceptorRegistrationResponse {
+  data: {
+    user: {
+      id: number;
+      name: string;
+      email: string;
+      phone_number: string;
+      role: string;
+    };
+    token: string;
+  };
+}
+
+export const receptorService = {
+  register: async (data: ReceptorRegistrationData): Promise<ReceptorRegistrationResponse> => {
+    try {
+      const response = await api.post<ReceptorRegistrationResponse>('/register/receptor', data);
+      return response.data;
+    } catch (error) {
+      console.error('Erro ao registrar receptor:', error);
+      throw error;
+    }
+  },
+};

--- a/mobile/stores/receptorRegistrationStore.ts
+++ b/mobile/stores/receptorRegistrationStore.ts
@@ -1,0 +1,111 @@
+import { receptorService, ReceptorRegistrationData } from '@/services/receptorService';
+import { create } from 'zustand';
+import * as Device from 'expo-device';
+import { useAuthStore } from './authStore';
+import { cleanNumeric } from '@/utils/validation/receptorValidation';
+
+export interface ReceptorRegistrationFormData {
+  name: string;
+  email: string;
+  cpf: string;
+  phone_number: string;
+  password: string;
+  password_confirmation: string;
+  terms_accepted: boolean;
+}
+
+interface ReceptorRegistrationFormStore {
+  formData: ReceptorRegistrationFormData;
+  isLoading: boolean;
+  error: string | null;
+  validationErrors: Record<string, string[]> | null;
+  updateFormData: (data: Partial<ReceptorRegistrationFormData>) => void;
+  submitRegistration: () => Promise<boolean>;
+  clearErrors: () => void;
+  resetForm: () => void;
+}
+
+const initialFormData: ReceptorRegistrationFormData = {
+  name: '',
+  email: '',
+  cpf: '',
+  phone_number: '',
+  password: '',
+  password_confirmation: '',
+  terms_accepted: false,
+};
+
+export const useReceptorRegistrationStore = create<ReceptorRegistrationFormStore>((set, get) => ({
+  formData: { ...initialFormData },
+  isLoading: false,
+  error: null,
+  validationErrors: null,
+
+  updateFormData: (data) =>
+    set((state) => ({
+      formData: {
+        ...state.formData,
+        ...data,
+      },
+    })),
+
+  clearErrors: () => set({ error: null, validationErrors: null }),
+
+  resetForm: () => set({ formData: { ...initialFormData }, error: null, validationErrors: null }),
+
+  submitRegistration: async () => {
+    set({ isLoading: true, error: null, validationErrors: null });
+
+    try {
+      const { formData } = get();
+      const deviceName = await getDeviceName();
+
+      const registrationData: ReceptorRegistrationData = {
+        name: formData.name.trim(),
+        email: formData.email.trim().toLowerCase(),
+        cpf: cleanNumeric(formData.cpf),
+        phone_number: cleanNumeric(formData.phone_number),
+        password: formData.password,
+        password_confirmation: formData.password_confirmation,
+        device_name: deviceName,
+        terms_accepted: formData.terms_accepted,
+      };
+
+      const response = await receptorService.register(registrationData);
+
+      const { user, token } = response.data;
+
+      await useAuthStore.getState().saveSession(user, token);
+
+      set({ isLoading: false });
+      return true;
+    } catch (error: any) {
+      if (error.isValidationError) {
+        set({
+          isLoading: false,
+          validationErrors: error.validationErrors,
+          error: error.message,
+        });
+      } else {
+        set({
+          isLoading: false,
+          error: error instanceof Error ? error.message : 'Erro ao cadastrar. Tente novamente.',
+        });
+      }
+
+      return false;
+    }
+  },
+}));
+
+async function getDeviceName(): Promise<string> {
+  try {
+    const deviceName =
+      Device.deviceName || `${Device.brand || ''} ${Device.modelName || ''}`.trim();
+
+    return deviceName || 'Dispositivo Desconhecido';
+  } catch (error) {
+    console.warn('Erro ao obter nome do dispositivo:', error);
+    return 'Mobile App';
+  }
+}

--- a/mobile/utils/validation/receptorValidation.ts
+++ b/mobile/utils/validation/receptorValidation.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod';
+
+/**
+ * Validates Brazilian CPF using the official algorithm.
+ * Checks both verification digits.
+ */
+const validateCPF = (cpf: string): boolean => {
+  // Remove non-numeric characters
+  const cleanCPF = cpf.replace(/\D/g, '');
+
+  if (cleanCPF.length !== 11) return false;
+
+  // Check for CPFs with all same digits
+  if (/^(\d)\1{10}$/.test(cleanCPF)) return false;
+
+  // Validate first check digit
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += parseInt(cleanCPF[i], 10) * (10 - i);
+  }
+  let remainder = sum % 11;
+  let firstCheckDigit = remainder < 2 ? 0 : 11 - remainder;
+
+  if (parseInt(cleanCPF[9], 10) !== firstCheckDigit) return false;
+
+  // Validate second check digit
+  sum = 0;
+  for (let i = 0; i < 10; i++) {
+    sum += parseInt(cleanCPF[i], 10) * (11 - i);
+  }
+  remainder = sum % 11;
+  let secondCheckDigit = remainder < 2 ? 0 : 11 - remainder;
+
+  if (parseInt(cleanCPF[10], 10) !== secondCheckDigit) return false;
+
+  return true;
+};
+
+/**
+ * Formats CPF with mask: 000.000.000-00
+ */
+export const formatCPF = (value: string): string => {
+  const cleanValue = value.replace(/\D/g, '');
+  const limitedValue = cleanValue.slice(0, 11);
+
+  if (limitedValue.length <= 3) {
+    return limitedValue;
+  }
+  if (limitedValue.length <= 6) {
+    return `${limitedValue.slice(0, 3)}.${limitedValue.slice(3)}`;
+  }
+  if (limitedValue.length <= 9) {
+    return `${limitedValue.slice(0, 3)}.${limitedValue.slice(3, 6)}.${limitedValue.slice(6)}`;
+  }
+  return `${limitedValue.slice(0, 3)}.${limitedValue.slice(3, 6)}.${limitedValue.slice(6, 9)}-${limitedValue.slice(9, 11)}`;
+};
+
+/**
+ * Formats phone number with mask: (00) 00000-0000 or (00) 0000-0000
+ */
+export const formatPhone = (value: string): string => {
+  const cleanValue = value.replace(/\D/g, '');
+  const limitedValue = cleanValue.slice(0, 11);
+
+  if (limitedValue.length <= 2) {
+    return limitedValue.length ? `(${limitedValue}` : '';
+  }
+  if (limitedValue.length <= 6) {
+    return `(${limitedValue.slice(0, 2)}) ${limitedValue.slice(2)}`;
+  }
+  if (limitedValue.length <= 10) {
+    return `(${limitedValue.slice(0, 2)}) ${limitedValue.slice(2, 6)}-${limitedValue.slice(6)}`;
+  }
+  return `(${limitedValue.slice(0, 2)}) ${limitedValue.slice(2, 7)}-${limitedValue.slice(7)}`;
+};
+
+/**
+ * Removes formatting from CPF or phone
+ */
+export const cleanNumeric = (value: string): string => {
+  return value.replace(/\D/g, '');
+};
+
+// Validation schemas
+export const receptorValidation = {
+  name: z
+    .string({ required_error: 'Nome é obrigatório' })
+    .min(3, 'Nome deve ter pelo menos 3 caracteres')
+    .max(255, 'Nome não pode ter mais de 255 caracteres'),
+
+  email: z
+    .string({ required_error: 'E-mail é obrigatório' })
+    .email('E-mail inválido')
+    .max(255, 'E-mail não pode ter mais de 255 caracteres'),
+
+  cpf: z
+    .string({ required_error: 'CPF é obrigatório' })
+    .refine((val) => cleanNumeric(val).length === 11, {
+      message: 'CPF deve ter 11 dígitos',
+    })
+    .refine((val) => validateCPF(val), {
+      message: 'CPF inválido',
+    }),
+
+  phone: z.string({ required_error: 'Telefone é obrigatório' }).refine(
+    (val) => {
+      const clean = cleanNumeric(val);
+      return clean.length >= 10 && clean.length <= 11;
+    },
+    {
+      message: 'Telefone deve ter 10 ou 11 dígitos',
+    }
+  ),
+
+  password: z
+    .string({ required_error: 'Senha é obrigatória' })
+    .min(8, 'Senha deve ter pelo menos 8 caracteres'),
+
+  passwordConfirmation: z.string({ required_error: 'Confirmação de senha é obrigatória' }),
+
+  termsAccepted: z.boolean().refine((val) => val === true, {
+    message: 'Você deve aceitar os termos de uso',
+  }),
+};
+
+export const receptorRegistrationSchema = z
+  .object({
+    name: receptorValidation.name,
+    email: receptorValidation.email,
+    cpf: receptorValidation.cpf,
+    phone_number: receptorValidation.phone,
+    password: receptorValidation.password,
+    password_confirmation: receptorValidation.passwordConfirmation,
+    terms_accepted: receptorValidation.termsAccepted,
+  })
+  .refine((data) => data.password === data.password_confirmation, {
+    message: 'As senhas não conferem',
+    path: ['password_confirmation'],
+  });
+
+export type ReceptorRegistrationFormData = z.infer<typeof receptorRegistrationSchema>;

--- a/web/app/Actions/Auth/CreateReceptorAction.php
+++ b/web/app/Actions/Auth/CreateReceptorAction.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\Auth;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Action to create a new receptor (patient) user.
+ *
+ * This action handles the creation of a receptor user with proper
+ * hashing of password and atomic database operations.
+ */
+class CreateReceptorAction
+{
+    /**
+     * Execute the action.
+     *
+     * @param  array{
+     *     name: string,
+     *     email: string,
+     *     cpf: string,
+     *     phone_number: string,
+     *     password: string,
+     *     terms_accepted: bool
+     * }  $data
+     */
+    public function execute(array $data): User
+    {
+        return DB::transaction(function () use ($data): User {
+            return User::create([
+                'name'              => $data['name'],
+                'email'             => $data['email'],
+                'cpf'               => $data['cpf'],
+                'role'              => 'receptor',
+                'phone_number'      => $data['phone_number'],
+                'password'          => Hash::make($data['password']),
+                'terms_accepted'    => $data['terms_accepted'],
+                'terms_accepted_at' => now(),
+            ]);
+        });
+    }
+}

--- a/web/app/Http/Controllers/Auth/ReceptorRegistrationController.php
+++ b/web/app/Http/Controllers/Auth/ReceptorRegistrationController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Auth;
+
+use App\Actions\Auth\CreateReceptorAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ReceptorRegistrationRequest;
+use App\Http\Resources\UserResource;
+use Symfony\Component\HttpFoundation\Response;
+
+class ReceptorRegistrationController extends Controller
+{
+    public function __construct(
+        private readonly CreateReceptorAction $createReceptorAction
+    ) {
+    }
+
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(ReceptorRegistrationRequest $request): Response
+    {
+        $user = $this->createReceptorAction->execute([
+            'name'           => $request->validated('name'),
+            'email'          => $request->validated('email'),
+            'cpf'            => $request->validated('cpf'),
+            'phone_number'   => $request->validated('phone_number'),
+            'password'       => $request->validated('password'),
+            'terms_accepted' => $request->validated('terms_accepted'),
+        ]);
+
+        $token = $user->createToken($request->validated('device_name'))->plainTextToken;
+
+        return response()->json([
+            'data' => [
+                'user'  => new UserResource($user),
+                'token' => $token,
+            ],
+        ], Response::HTTP_CREATED);
+    }
+}

--- a/web/app/Http/Requests/Auth/ReceptorRegistrationRequest.php
+++ b/web/app/Http/Requests/Auth/ReceptorRegistrationRequest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Requests\Auth;
+
+use App\Models\User;
+use App\Rules\ValidCPF;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules;
+
+class ReceptorRegistrationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name'           => ['required', 'string', 'max:255'],
+            'email'          => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
+            'cpf'            => ['required', 'string', new ValidCPF(), 'unique:' . User::class . ',cpf'],
+            'phone_number'   => ['required', 'string', 'min:10', 'max:11', 'unique:' . User::class . ',phone_number'],
+            'password'       => ['required', 'confirmed', Rules\Password::defaults()],
+            'device_name'    => ['required', 'string', 'max:255'],
+            'terms_accepted' => ['required', 'accepted'],
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'email'        => is_string($email = $this->input('email')) ? mb_strtolower($email) : '',
+            'phone_number' => $this->cleanNumeric($this->input('phone_number')),
+            'cpf'          => $this->cleanNumeric($this->input('cpf')),
+        ]);
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required'           => 'O nome é obrigatório.',
+            'name.max'                => 'O nome não pode ter mais de 255 caracteres.',
+            'email.required'          => 'O e-mail é obrigatório.',
+            'email.email'             => 'O e-mail deve ser um endereço de e-mail válido.',
+            'email.unique'            => 'Este e-mail já está cadastrado.',
+            'cpf.required'            => 'O CPF é obrigatório.',
+            'cpf.unique'              => 'Este CPF já está cadastrado.',
+            'phone_number.required'   => 'O telefone é obrigatório.',
+            'phone_number.min'        => 'O telefone deve ter pelo menos 10 dígitos.',
+            'phone_number.max'        => 'O telefone deve ter no máximo 11 dígitos.',
+            'phone_number.unique'     => 'Este telefone já está cadastrado.',
+            'password.required'       => 'A senha é obrigatória.',
+            'password.confirmed'      => 'A confirmação de senha não confere.',
+            'device_name.required'    => 'O nome do dispositivo é obrigatório.',
+            'terms_accepted.required' => 'Você deve aceitar os termos de uso.',
+            'terms_accepted.accepted' => 'Você deve aceitar os termos de uso.',
+        ];
+    }
+
+    /**
+     * Clean numeric values (remove non-numeric characters).
+     */
+    private function cleanNumeric(mixed $value): string
+    {
+        if (! is_string($value)) {
+            return '';
+        }
+
+        return preg_replace('/\D/', '', $value) ?? '';
+    }
+}

--- a/web/app/Http/Resources/UserResource.php
+++ b/web/app/Http/Resources/UserResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\User
+ */
+class UserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'           => $this->id,
+            'name'         => $this->name,
+            'email'        => $this->email,
+            'phone_number' => $this->phone_number,
+            'role'         => $this->role,
+            'created_at'   => $this->created_at,
+            'updated_at'   => $this->updated_at,
+        ];
+    }
+}

--- a/web/app/Models/User.php
+++ b/web/app/Models/User.php
@@ -23,6 +23,8 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $fillable = [
         'name',
         'email',
+        'cpf',
+        'role',
         'password',
         'phone_number',
         'terms_accepted',

--- a/web/app/Rules/ValidCPF.php
+++ b/web/app/Rules/ValidCPF.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Rule to validate Brazilian CPF (Cadastro de Pessoas Físicas).
+ *
+ * This rule validates the CPF using the official algorithm that checks
+ * the two verification digits at the end of the CPF number.
+ */
+class ValidCPF implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            $fail("O campo {$attribute} deve ser uma string.");
+
+            return;
+        }
+
+        // Remove any non-numeric characters
+        $cpf = preg_replace('/\D/', '', $value);
+
+        if ($cpf === null || mb_strlen($cpf) !== 11) {
+            $fail("O campo {$attribute} deve conter 11 dígitos.");
+
+            return;
+        }
+
+        // Check for CPFs with all same digits (e.g., 111.111.111-11)
+        if (preg_match('/^(\d)\1{10}$/', $cpf)) {
+            $fail("O campo {$attribute} é inválido.");
+
+            return;
+        }
+
+        // Validate first check digit
+        if (! $this->validateCheckDigit($cpf, 9)) {
+            $fail("O campo {$attribute} é inválido.");
+
+            return;
+        }
+
+        // Validate second check digit
+        if (! $this->validateCheckDigit($cpf, 10)) {
+            $fail("O campo {$attribute} é inválido.");
+
+            return;
+        }
+    }
+
+    /**
+     * Validate a check digit of the CPF.
+     *
+     * @param  string  $cpf  The CPF number (only digits)
+     * @param  int  $position  The position of the check digit (9 or 10)
+     */
+    private function validateCheckDigit(string $cpf, int $position): bool
+    {
+        $sum        = 0;
+        $multiplier = $position + 1;
+
+        for ($i = 0; $i < $position; $i++) {
+            $sum += (int) $cpf[$i] * $multiplier;
+            $multiplier--;
+        }
+
+        $remainder  = $sum % 11;
+        $checkDigit = $remainder < 2 ? 0 : 11 - $remainder;
+
+        return (int) $cpf[$position] === $checkDigit;
+    }
+}

--- a/web/database/factories/UserFactory.php
+++ b/web/database/factories/UserFactory.php
@@ -29,8 +29,10 @@ class UserFactory extends Factory
         return [
             'name'              => fake()->name(),
             'email'             => fake()->unique()->safeEmail(),
+            'cpf'               => fake()->unique()->numerify('###########'),
+            'role'              => 'receptor',
             'email_verified_at' => now(),
-            'phone_number'      => fake()->phoneNumber(),
+            'phone_number'      => fake()->numerify('###########'),
             'terms_accepted'    => true,
             'terms_accepted_at' => now(),
             'password'          => static::$password ??= Hash::make('password'),
@@ -50,7 +52,9 @@ class UserFactory extends Factory
 
     public function doctor(?string $crm = null, ?string $crm_uf = null): static
     {
-        return $this->afterCreating(function ($user) use ($crm, $crm_uf): void {
+        return $this->state(fn (array $attributes): array => [
+            'role' => 'doctor',
+        ])->afterCreating(function ($user) use ($crm, $crm_uf): void {
             $doctorAttributes = array_filter([
                 'user_id' => $user->id,
                 'crm'     => $crm,
@@ -59,5 +63,15 @@ class UserFactory extends Factory
 
             Doctor::factory()->create($doctorAttributes);
         });
+    }
+
+    /**
+     * Indicate that the user is a receptor (patient).
+     */
+    public function receptor(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'role' => 'receptor',
+        ]);
     }
 }

--- a/web/database/migrations/2025_11_29_022758_add_cpf_and_role_to_users_table.php
+++ b/web/database/migrations/2025_11_29_022758_add_cpf_and_role_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('cpf', 11)->nullable()->unique()->after('email');
+            $table->enum('role', ['doctor', 'receptor'])->default('receptor')->after('cpf');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn(['cpf', 'role']);
+        });
+    }
+};

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Auth;
 use App\Http\Controllers\Api\V1\Drug;
 use App\Http\Controllers\Api\V1\MedicationOffering;
 use App\Http\Controllers\Auth\DoctorRegistrationController;
+use App\Http\Controllers\Auth\ReceptorRegistrationController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -14,6 +15,10 @@ Route::middleware(['auth:sanctum'])->get('/user', fn (Request $request) => $requ
 Route::post('/register/doctor', DoctorRegistrationController::class)
     ->middleware('guest')
     ->name('doctor.register');
+
+Route::post('/register/receptor', ReceptorRegistrationController::class)
+    ->middleware('guest')
+    ->name('receptor.register');
 
 Route::prefix('v1')->group(function (): void {
     Route::prefix('auth')->group(function (): void {

--- a/web/tests/Feature/Auth/RegisterReceptorTest.php
+++ b/web/tests/Feature/Auth/RegisterReceptorTest.php
@@ -1,0 +1,510 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\postJson;
+use function PHPUnit\Framework\assertTrue;
+
+/*
+|--------------------------------------------------------------------------
+| Receptor (Patient) Registration Tests
+|--------------------------------------------------------------------------
+|
+| Test suite for receptor/patient registration endpoint following TDD approach.
+| Tests cover: successful registration, validation errors, and security.
+|
+*/
+
+describe('Receptor Registration - Success Scenarios', function (): void {
+    it('should register a receptor successfully and return 201 with token', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Maria Silva',
+            'email'                 => 'maria@example.com',
+            'cpf'                   => '529.982.247-25', // CPF válido
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'iPhone 15',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertCreated();
+        $response->assertJsonStructure([
+            'data' => [
+                'user' => ['id', 'name', 'email', 'phone_number', 'role'],
+                'token',
+            ],
+        ]);
+
+        // Verify user was created in database
+        assertDatabaseHas('users', [
+            'name'         => 'Maria Silva',
+            'email'        => 'maria@example.com',
+            'cpf'          => '52998224725', // Stored without mask
+            'phone_number' => '11987654321',
+            'role'         => 'receptor',
+        ]);
+
+        assertDatabaseCount('users', 1);
+    });
+
+    it('should return a valid Sanctum token upon successful registration', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'João Santos',
+            'email'                 => 'joao@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(21) 99876-5432',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Samsung Galaxy',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertCreated();
+
+        $token = $response->json('data.token');
+        expect($token)->not->toBeEmpty();
+
+        // Verify token was created in database
+        $user = User::whereEmail('joao@example.com')->first();
+        expect($user->tokens)->toHaveCount(1);
+    });
+
+    it('should hash the password correctly', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Ana Costa',
+            'email'                 => 'ana@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(31) 98765-1234',
+            'password'              => 'MyPassword123!',
+            'password_confirmation' => 'MyPassword123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+
+        $user = User::whereEmail('ana@example.com')->first();
+        assertTrue(password_verify('MyPassword123!', (string) $user->password));
+    });
+
+    it('should NOT return password in response', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Pedro Lima',
+            'email'                 => 'pedro@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(41) 98765-4321',
+            'password'              => 'SecurePassword123!',
+            'password_confirmation' => 'SecurePassword123!',
+            'device_name'           => 'Pixel 8',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertCreated();
+
+        $userData = $response->json('data.user');
+        expect($userData)->not->toHaveKey('password');
+        expect($userData)->not->toHaveKey('remember_token');
+    });
+
+    it('should set role as receptor', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Lucas Oliveira',
+            'email'                 => 'lucas@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(51) 98765-4321',
+            'password'              => 'TestPassword123!',
+            'password_confirmation' => 'TestPassword123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertCreated();
+        expect($response->json('data.user.role'))->toBe('receptor');
+
+        assertDatabaseHas('users', [
+            'email' => 'lucas@example.com',
+            'role'  => 'receptor',
+        ]);
+    });
+});
+
+describe('Receptor Registration - Validation Errors', function (): void {
+    it('should return 422 when name is missing', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'email'                 => 'test@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['name']);
+    });
+
+    it('should return 422 when email is invalid', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'invalid-email',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['email']);
+    });
+
+    it('should return 422 when email is already registered', function (): void {
+        User::factory()->create(['email' => 'existing@example.com']);
+
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'New User',
+            'email'                 => 'existing@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['email']);
+    });
+
+    it('should return 422 when CPF is invalid (wrong check digits)', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '123.456.789-00', // Invalid CPF
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['cpf']);
+    });
+
+    it('should return 422 when CPF has all same digits', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '111.111.111-11', // All same digits
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['cpf']);
+    });
+
+    it('should return 422 when CPF is already registered', function (): void {
+        User::factory()->create(['cpf' => '52998224725']);
+
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'New User',
+            'email'                 => 'new@example.com',
+            'cpf'                   => '529.982.247-25', // Same CPF
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['cpf']);
+    });
+
+    it('should return 422 when phone number is already registered', function (): void {
+        User::factory()->create(['phone_number' => '11987654321']);
+
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'New User',
+            'email'                 => 'new@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321', // Same phone number
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['phone_number']);
+    });
+
+    it('should return 422 when phone number is too short', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '1234567', // Too short
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['phone_number']);
+    });
+
+    it('should return 422 when password is too short', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => '123', // Too short
+            'password_confirmation' => '123',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['password']);
+    });
+
+    it('should return 422 when password confirmation does not match', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'DifferentPassword!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['password']);
+    });
+
+    it('should return 422 when terms are not accepted', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => false,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['terms_accepted']);
+    });
+
+    it('should return 422 when device name is missing', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => 'test@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['device_name']);
+    });
+});
+
+describe('Receptor Registration - Security Tests', function (): void {
+    it('should sanitize CPF input (remove mask)', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Security Test',
+            'email'                 => 'security@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+
+        assertDatabaseHas('users', [
+            'cpf' => '52998224725', // Stored without mask
+        ]);
+    });
+
+    it('should sanitize phone number input (remove mask)', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Phone Test',
+            'email'                 => 'phone@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+
+        assertDatabaseHas('users', [
+            'phone_number' => '11987654321', // Stored without mask
+        ]);
+    });
+
+    it('should reject SQL injection attempts in name field', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => "Robert'); DROP TABLE users;--",
+            'email'                 => 'injection@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        // Should either create with sanitized name or reject
+        // Laravel's Eloquent uses parameterized queries, so it should be safe
+        if ($response->status() === 201) {
+            // If created, verify the injection didn't work
+            assertDatabaseHas('users', [
+                'email' => 'injection@example.com',
+            ]);
+            assertDatabaseCount('users', 1);
+        }
+    });
+
+    it('should reject SQL injection attempts in email field', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Test User',
+            'email'                 => "test@example.com'; DROP TABLE users;--",
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        // Should reject because it's not a valid email format
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['email']);
+        assertDatabaseMissing('users', ['name' => 'Test User']);
+    });
+
+    it('should convert email to lowercase', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Uppercase Email',
+            'email'                 => 'TEST@EXAMPLE.COM',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+
+        assertDatabaseHas('users', [
+            'email' => 'test@example.com', // Stored in lowercase
+        ]);
+    });
+
+    it('should set terms_accepted_at timestamp', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Terms Test',
+            'email'                 => 'terms@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+
+        $user = User::whereEmail('terms@example.com')->first();
+        expect($user->terms_accepted_at)->not->toBeNull();
+    });
+});
+
+describe('Receptor Registration - CPF Validation Algorithm', function (): void {
+    it('should accept valid CPF: 529.982.247-25', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Valid CPF 1',
+            'email'                 => 'valid1@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+    });
+
+    it('should accept valid CPF without mask: 52998224725', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Valid CPF 2',
+            'email'                 => 'valid2@example.com',
+            'cpf'                   => '52998224725',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+    });
+
+    it('should accept another valid CPF: 145.382.206-20', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Valid CPF 3',
+            'email'                 => 'valid3@example.com',
+            'cpf'                   => '145.382.206-20',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+    });
+
+    it('should reject CPF with wrong first check digit', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Invalid CPF',
+            'email'                 => 'invalid@example.com',
+            'cpf'                   => '529.982.247-15', // Wrong check digit
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['cpf']);
+    });
+
+    it('should reject CPF with wrong second check digit', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Invalid CPF',
+            'email'                 => 'invalid@example.com',
+            'cpf'                   => '529.982.247-26', // Wrong check digit
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['cpf']);
+    });
+});


### PR DESCRIPTION
Esta funcionalidade introduz o fluxo completo de cadastro para usuários do tipo "receptor" (paciente), abrangendo desde a interface no aplicativo móvel até a API no backend. Foram adicionados novos campos de `cpf` e `role` à tabela de usuários para suportar a diferenciação entre tipos de usuário.

### Principais Mudanças:

*   **Banco de Dados:**
    *   Adicionada uma nova migration que inclui as colunas `cpf` (único) e `role` (enum: `doctor`, `receptor`) na tabela `users`.
    *   Atualizada a `UserFactory` para acomodar os novos campos e adicionar um state `receptor()`.
*   **Backend (API):**
    *   Criada a rota `POST /register/receptor` para lidar com o novo fluxo de cadastro.
    *   Desenvolvido o `ReceptorRegistrationController` e a `CreateReceptorAction` para orquestrar a criação do usuário de forma transacional e segura.
    *   Implementado o `ReceptorRegistrationRequest` com regras de validação robustas, incluindo sanitização de CPF e telefone.
    *   Adicionada uma regra de validação customizada (`ValidCPF`) para garantir a integridade dos CPFs cadastrados.
    *   Introduzido um `UserResource` para padronizar a resposta da API e evitar o vazamento de dados sensíveis.
*   **Frontend (Mobile):**
    *   Desenvolvida a nova tela `ReceptorRegistrationScreen` com um formulário completo para o cadastro do paciente.
    *   Implementado o `receptorRegistrationStore` (Zustand) para gerenciar o estado do formulário, validações e comunicação com a API.
    *   Adicionada validação do lado do cliente com `zod` em `receptorValidation.ts`, incluindo máscaras e validação de CPF.
    *   Atualizada a tela de seleção de tipo de usuário para direcionar para o novo fluxo de cadastro de paciente.
*   **Testes:**
    *   Adicionada uma suíte de testes de feature (`RegisterReceptorTest.php`) com Pest, cobrindo cenários de sucesso, falhas de validação e segurança para o novo endpoint.