### PR TITLE
feat: add medication history screen for receptors

### DIFF
--- a/mobile/app/(auth)/receptor/(tabs)/_layout.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/_layout.tsx
@@ -58,6 +58,16 @@ export default function ReceptorTabsLayout() {
           headerTitle: 'Meus Agendamentos',
         }}
       />
+      <Tabs.Screen
+        name="history"
+        options={{
+          title: 'Histórico',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="time-outline" size={size} color={color} />
+          ),
+          headerTitle: 'Histórico de Medicamentos',
+        }}
+      />
     </Tabs>
   );
 }

--- a/mobile/app/(auth)/receptor/(tabs)/history.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/history.tsx
@@ -1,0 +1,315 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
+import { useMedicationAppointmentStore } from '@/stores/medicationAppointmentStore';
+import { Colors } from '@/constants/Colors';
+import { MedicationAppointment } from '@/types/medicationAppointment';
+
+export default function ReceptorHistoryScreen() {
+  const { history, isLoading, error, fetchHistory, clearError } = useMedicationAppointmentStore();
+
+  useEffect(() => {
+    fetchHistory();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    });
+  };
+
+  const renderItem = ({ item }: { item: MedicationAppointment }) => {
+    const drug = item.medication_request?.medication_offering?.drug;
+    const doctor = item.medication_request?.medication_offering?.doctor;
+
+    return (
+      <View style={styles.card}>
+        <View style={styles.cardHeader}>
+          <Text style={styles.medicationName}>{drug?.product_name || 'Medicamento'}</Text>
+          <View style={styles.statusBadge}>
+            <Text style={styles.statusText}>Recebido</Text>
+          </View>
+        </View>
+
+        <View style={styles.cardContent}>
+          {drug?.substance && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Substância:</Text>
+              <Text style={styles.infoValue}>{drug.substance}</Text>
+            </View>
+          )}
+
+          {drug?.laboratory && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Laboratório:</Text>
+              <Text style={styles.infoValue}>{drug.laboratory}</Text>
+            </View>
+          )}
+
+          {item.medication_request?.medication_offering?.lot_number && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Lote:</Text>
+              <Text style={styles.infoValue}>
+                {item.medication_request.medication_offering.lot_number}
+              </Text>
+            </View>
+          )}
+
+          {item.medication_request?.medication_offering?.expires_at && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Validade:</Text>
+              <Text style={styles.infoValue}>
+                {formatDate(item.medication_request.medication_offering.expires_at)}
+              </Text>
+            </View>
+          )}
+
+          {doctor?.name && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Doador:</Text>
+              <Text style={styles.infoValue}>{doctor.name}</Text>
+            </View>
+          )}
+
+          <View style={styles.divider} />
+
+          <View style={styles.dateRow}>
+            <Text style={styles.dateIcon}>📅</Text>
+            <Text style={styles.dateText}>Recebido em {formatDate(item.updated_at)}</Text>
+          </View>
+        </View>
+      </View>
+    );
+  };
+
+  const renderEmpty = () => {
+    if (isLoading) return null;
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyIcon}>📦</Text>
+        <Text style={styles.emptyTitle}>Nenhum medicamento recebido</Text>
+        <Text style={styles.emptyText}>
+          Quando você receber medicamentos, eles aparecerão aqui.
+        </Text>
+        <Text style={styles.emptyHint}>
+          Busque medicamentos disponíveis e faça solicitações para começar.
+        </Text>
+      </View>
+    );
+  };
+
+  if (error) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorIcon}>⚠️</Text>
+        <Text style={styles.errorText}>{error}</Text>
+        <Text
+          style={styles.retryText}
+          onPress={() => {
+            clearError();
+            fetchHistory();
+          }}
+        >
+          Tentar novamente
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Header info */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Seu histórico de medicamentos</Text>
+        <Text style={styles.headerSubtitle}>
+          {history.length}{' '}
+          {history.length === 1 ? 'medicamento recebido' : 'medicamentos recebidos'}
+        </Text>
+      </View>
+
+      {isLoading && history.length === 0 ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.yellow_green_500} />
+          <Text style={styles.loadingText}>Carregando histórico...</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={history}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={isLoading}
+              onRefresh={fetchHistory}
+              colors={[Colors.yellow_green_500]}
+              tintColor={Colors.yellow_green_500}
+            />
+          }
+          ListEmptyComponent={renderEmpty}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f3f4f6',
+  },
+  header: {
+    backgroundColor: '#ffffff',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: '#6b7280',
+    marginTop: 4,
+  },
+  listContent: {
+    padding: 16,
+    flexGrow: 1,
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 2,
+    overflow: 'hidden',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: '#f0fdf4',
+    borderBottomWidth: 1,
+    borderBottomColor: '#dcfce7',
+  },
+  medicationName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2937',
+    flex: 1,
+    marginRight: 8,
+  },
+  statusBadge: {
+    backgroundColor: '#22c55e',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  statusText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  cardContent: {
+    padding: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    marginBottom: 8,
+  },
+  infoLabel: {
+    fontSize: 14,
+    color: '#6b7280',
+    width: 100,
+  },
+  infoValue: {
+    fontSize: 14,
+    color: '#1f2937',
+    flex: 1,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#e5e7eb',
+    marginVertical: 12,
+  },
+  dateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  dateIcon: {
+    fontSize: 16,
+    marginRight: 8,
+  },
+  dateText: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  emptyIcon: {
+    fontSize: 64,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#1f2937',
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#6b7280',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  emptyHint: {
+    fontSize: 14,
+    color: '#9ca3af',
+    textAlign: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  errorIcon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#ef4444',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  retryText: {
+    fontSize: 16,
+    color: Colors.yellow_green_500,
+    fontWeight: '600',
+  },
+});

--- a/mobile/services/medicationAppointmentService.ts
+++ b/mobile/services/medicationAppointmentService.ts
@@ -98,4 +98,16 @@ export const medicationAppointmentService = {
       throw new Error(extractErrorMessage(error));
     }
   },
+
+  /**
+   * List receptor's medication history (completed appointments)
+   */
+  listHistory: async (): Promise<MedicationAppointment[]> => {
+    try {
+      const response = await api.get('/v1/medication-appointments/history');
+      return response.data.data;
+    } catch (error: any) {
+      throw new Error(extractErrorMessage(error));
+    }
+  },
 };

--- a/mobile/stores/medicationAppointmentStore.ts
+++ b/mobile/stores/medicationAppointmentStore.ts
@@ -12,6 +12,8 @@ interface MedicationAppointmentStoreState {
   appointments: MedicationAppointment[];
   // Doctor's received appointments
   receivedAppointments: MedicationAppointment[];
+  // Receptor's medication history (completed appointments)
+  history: MedicationAppointment[];
   isLoading: boolean;
   error: string | null;
 
@@ -19,6 +21,7 @@ interface MedicationAppointmentStoreState {
   fetchMyAppointments: (status?: MedicationAppointmentStatus) => Promise<void>;
   createAppointment: (data: CreateMedicationAppointmentData) => Promise<MedicationAppointment>;
   confirmDeliveryReceptor: (id: number) => Promise<void>;
+  fetchHistory: () => Promise<void>;
 
   // Doctor actions
   fetchReceivedAppointments: (status?: MedicationAppointmentStatus) => Promise<void>;
@@ -38,6 +41,7 @@ interface MedicationAppointmentStoreState {
 export const useMedicationAppointmentStore = create<MedicationAppointmentStoreState>((set) => ({
   appointments: [],
   receivedAppointments: [],
+  history: [],
   isLoading: false,
   error: null,
 
@@ -79,6 +83,17 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
         isLoading: false,
         error: null,
       }));
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false });
+      throw error;
+    }
+  },
+
+  fetchHistory: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const history = await medicationAppointmentService.listHistory();
+      set({ history, isLoading: false, error: null });
     } catch (error: any) {
       set({ error: error.message, isLoading: false });
       throw error;

--- a/web/app/Actions/MedicationAppointment/ListReceptorHistoryAction.php
+++ b/web/app/Actions/MedicationAppointment/ListReceptorHistoryAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\MedicationAppointment;
+
+use App\Models\MedicationAppointment;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+
+class ListReceptorHistoryAction
+{
+    /**
+     * Execute the action to list receptor's completed appointments (medication history).
+     *
+     * @return Collection<int, MedicationAppointment>
+     */
+    public function execute(User $receptor): Collection
+    {
+        return MedicationAppointment::query()
+            ->whereHas('medicationRequest', fn ($q) => $q->where('receptor_id', $receptor->id))
+            ->completed()
+            ->with([
+                'medicationRequest.medicationOffering.drug',
+                'medicationRequest.medicationOffering.doctor.user',
+                'address',
+            ])
+            ->orderByDesc('updated_at')
+            ->get();
+    }
+}

--- a/web/app/Http/Controllers/Api/V1/MedicationAppointment/HistoryController.php
+++ b/web/app/Http/Controllers/Api/V1/MedicationAppointment/HistoryController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\MedicationAppointment;
+
+use App\Actions\MedicationAppointment\ListReceptorHistoryAction;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\MedicationAppointmentResource;
+use App\Models\MedicationAppointment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class HistoryController extends Controller
+{
+    /**
+     * Handle the incoming request to list receptor's medication history.
+     */
+    public function __invoke(
+        Request $request,
+        ListReceptorHistoryAction $action
+    ): AnonymousResourceCollection {
+        $this->authorize('viewOwn', MedicationAppointment::class);
+
+        $appointments = $action->execute($request->user());
+
+        return MedicationAppointmentResource::collection($appointments);
+    }
+}

--- a/web/database/seeders/DatabaseSeeder.php
+++ b/web/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
      * - 10 real medications (Losartana, Metformina, Omeprazol, etc.)
      * - 5 medication offerings from the doctor
      * - Sample requests and appointments for testing
+     * - 3 completed appointments for medication history (receptor)
      */
     public function run(): void
     {
@@ -35,6 +36,9 @@ class DatabaseSeeder extends Seeder
 
             // 4. Create requests and appointments (requires all above)
             MedicationRequestSeeder::class,
+
+            // 5. Create completed appointments for medication history
+            MedicationHistorySeeder::class,
         ]);
 
         $this->command->info('');

--- a/web/database/seeders/MedicationHistorySeeder.php
+++ b/web/database/seeders/MedicationHistorySeeder.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Database\Seeders;
+
+use App\Models\Drug;
+use App\Models\MedicationAppointment;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+
+class MedicationHistorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * Creates completed appointments to populate the receptor's medication history.
+     * These represent medications that have already been delivered.
+     */
+    public function run(): void
+    {
+        $receptor = User::where('email', 'receptor@example.com')->first();
+        $doctor   = User::where('email', 'doctor@example.com')->first();
+
+        if (! $receptor) {
+            $this->command->warn('Receptor user not found. Run ReceptorUserSeeder first.');
+
+            return;
+        }
+
+        if (! $doctor || ! $doctor->doctor) {
+            $this->command->warn('Doctor user not found. Run DoctorUserSeeder first.');
+
+            return;
+        }
+
+        $doctorAddress = $doctor->addresses()->first();
+
+        if (! $doctorAddress) {
+            $this->command->warn('Doctor has no address. Update DoctorUserSeeder.');
+
+            return;
+        }
+
+        // Get some drugs for the history
+        $drugs = Drug::take(8)->get();
+
+        if ($drugs->count() < 3) {
+            $this->command->warn('Not enough drugs found. Run DrugSeeder first.');
+
+            return;
+        }
+
+        // Create completed offerings and appointments (history)
+        $historyItems = [
+            [
+                'drug_index'     => 5, // Different from regular offerings
+                'lot_number'     => 'HIST2024A001',
+                'quantity'       => 20,
+                'days_ago'       => 30, // Received 30 days ago
+                'expires_months' => 3,
+            ],
+            [
+                'drug_index'     => 6,
+                'lot_number'     => 'HIST2024B002',
+                'quantity'       => 15,
+                'days_ago'       => 14, // Received 14 days ago
+                'expires_months' => 5,
+            ],
+            [
+                'drug_index'     => 7,
+                'lot_number'     => 'HIST2024C003',
+                'quantity'       => 30,
+                'days_ago'       => 7, // Received 7 days ago
+                'expires_months' => 8,
+            ],
+        ];
+
+        foreach ($historyItems as $item) {
+            $drugIndex = $item['drug_index'];
+            $drug      = $drugs[$drugIndex] ?? $drugs[0];
+
+            // Create a completed offering
+            $offering = MedicationOffering::create([
+                'doctor_id'  => $doctor->doctor->id,
+                'drug_id'    => $drug->id,
+                'lot_number' => $item['lot_number'],
+                'expires_at' => Carbon::now()->addMonths($item['expires_months']),
+                'quantity'   => 0, // All delivered
+                'status'     => 'completed',
+            ]);
+
+            // Create a confirmed request
+            $request = MedicationRequest::create([
+                'receptor_id'            => $receptor->id,
+                'medication_offering_id' => $offering->id,
+                'status'                 => 'confirmed',
+            ]);
+
+            // Create a completed appointment (this appears in history)
+            $appointmentDate = Carbon::now()->subDays($item['days_ago']);
+            MedicationAppointment::create([
+                'medication_request_id' => $request->id,
+                'address_id'            => $doctorAddress->id,
+                'scheduled_date'        => $appointmentDate->format('Y-m-d'),
+                'scheduled_time'        => '10:00:00',
+                'status'                => 'completed',
+                'proposed_by'           => 'receptor',
+                'receptor_confirmed'    => true,
+                'doctor_confirmed'      => true,
+                'created_at'            => $appointmentDate->subDays(7),
+                'updated_at'            => $appointmentDate, // Completion date
+            ]);
+        }
+
+        $this->command->info('Created ' . count($historyItems) . ' completed appointments for medication history.');
+    }
+}

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -82,6 +82,8 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.medication-appointments.list');
         Route::post('/', MedicationAppointment\StoreController::class)
             ->name('api.v1.medication-appointments.store');
+        Route::get('/history', MedicationAppointment\HistoryController::class)
+            ->name('api.v1.medication-appointments.history');
         Route::get('/received', MedicationAppointment\ReceivedController::class)
             ->name('api.v1.medication-appointments.received');
         Route::patch(

--- a/web/tests/Feature/Api/V1/MedicationAppointment/HistoryTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/HistoryTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\Address;
+use App\Models\Doctor;
+use App\Models\MedicationAppointment;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+// Happy Path Tests
+
+it('should return list of completed appointments (medication history)', function (): void {
+    $receptor = User::factory()->receptor()->create();
+    $doctor   = Doctor::factory()->create();
+    $address  = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $request  = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering)
+        ->confirmed()
+        ->create();
+    $appointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($receptor);
+
+    $response = getJson('/api/v1/medication-appointments/history');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $appointment->id)
+        ->assertJsonPath('data.0.status', 'completed');
+});
+
+it('should return history with correct structure including drug and doctor info', function (): void {
+    $receptor = User::factory()->receptor()->create();
+    $doctor   = Doctor::factory()->create();
+    $address  = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $request  = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering)
+        ->confirmed()
+        ->create();
+    MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($receptor);
+
+    $response = getJson('/api/v1/medication-appointments/history');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'scheduled_date',
+                    'scheduled_time',
+                    'status',
+                    'receptor_confirmed',
+                    'doctor_confirmed',
+                    'medication_request' => [
+                        'id',
+                        'status',
+                        'medication_offering' => [
+                            'id',
+                            'quantity',
+                            'lot_number',
+                            'expires_at',
+                            'status',
+                            'drug' => [
+                                'id',
+                                'product_name',
+                                'substance',
+                                'presentation',
+                                'laboratory',
+                            ],
+                            'doctor' => [
+                                'id',
+                                'name',
+                            ],
+                        ],
+                    ],
+                    'address',
+                ],
+            ],
+        ]);
+});
+
+it('should return empty list when receptor has no completed appointments', function (): void {
+    $receptor = User::factory()->receptor()->create();
+
+    actingAs($receptor);
+
+    getJson('/api/v1/medication-appointments/history')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('should only return completed appointments, not proposed or confirmed', function (): void {
+    $receptor  = User::factory()->receptor()->create();
+    $doctor    = Doctor::factory()->create();
+    $address   = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering1 = MedicationOffering::factory()->reserved()->create(['doctor_id' => $doctor->id]);
+    $offering2 = MedicationOffering::factory()->reserved()->create(['doctor_id' => $doctor->id]);
+    $offering3 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+
+    $request1 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering1)
+        ->confirmed()
+        ->create();
+    $request2 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering2)
+        ->confirmed()
+        ->create();
+    $request3 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering3)
+        ->confirmed()
+        ->create();
+
+    // Proposed appointment - should NOT appear in history
+    MedicationAppointment::factory()->proposed()->create([
+        'medication_request_id' => $request1->id,
+        'address_id'            => $address->id,
+    ]);
+    // Confirmed appointment - should NOT appear in history
+    MedicationAppointment::factory()->confirmed()->create([
+        'medication_request_id' => $request2->id,
+        'address_id'            => $address->id,
+    ]);
+    // Completed appointment - should appear in history
+    $completedAppointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request3->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($receptor);
+
+    $response = getJson('/api/v1/medication-appointments/history');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $completedAppointment->id);
+});
+
+it('should only return own completed appointments', function (): void {
+    $receptor1 = User::factory()->receptor()->create();
+    $receptor2 = User::factory()->receptor()->create();
+    $doctor    = Doctor::factory()->create();
+    $address   = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering1 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $offering2 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+
+    $request1 = MedicationRequest::factory()
+        ->forReceptor($receptor1)
+        ->forOffering($offering1)
+        ->confirmed()
+        ->create();
+    $request2 = MedicationRequest::factory()
+        ->forReceptor($receptor2)
+        ->forOffering($offering2)
+        ->confirmed()
+        ->create();
+
+    $apt1 = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request1->id,
+        'address_id'            => $address->id,
+    ]);
+    MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request2->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($receptor1);
+
+    $response = getJson('/api/v1/medication-appointments/history');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $apt1->id);
+});
+
+it('should return history sorted by completion date (most recent first)', function (): void {
+    $receptor  = User::factory()->receptor()->create();
+    $doctor    = Doctor::factory()->create();
+    $address   = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering1 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $offering2 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+
+    $request1 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering1)
+        ->confirmed()
+        ->create();
+    $request2 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering2)
+        ->confirmed()
+        ->create();
+
+    // Older completed appointment
+    $apt1 = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request1->id,
+        'address_id'            => $address->id,
+        'updated_at'            => now()->subDays(5),
+    ]);
+    // More recent completed appointment
+    $apt2 = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request2->id,
+        'address_id'            => $address->id,
+        'updated_at'            => now()->subDays(2),
+    ]);
+
+    actingAs($receptor);
+
+    $response = getJson('/api/v1/medication-appointments/history');
+
+    $response->assertOk()
+        ->assertJsonPath('data.0.id', $apt2->id)
+        ->assertJsonPath('data.1.id', $apt1->id);
+});
+
+// Authorization Error Tests
+
+it('should return 401 for unauthenticated users', function (): void {
+    getJson('/api/v1/medication-appointments/history')
+        ->assertUnauthorized();
+});
+
+it('should return 403 when doctor tries to access history', function (): void {
+    $doctor = Doctor::factory()->create();
+
+    actingAs($doctor->user);
+
+    getJson('/api/v1/medication-appointments/history')
+        ->assertForbidden();
+});


### PR DESCRIPTION
## Summary

- **Backend:** Add `GET /v1/medication-appointments/history` endpoint that returns completed appointments for receptors with medication and doctor details
- **Mobile:** Add new "Histórico" tab in receptor navigation showing all received medications
- **Seeders:** Add `MedicationHistorySeeder` to create test data for manual testing

## Changes

### Backend (API)
- Create `ListReceptorHistoryAction` to fetch completed appointments ordered by completion date (most recent first)
- Create `HistoryController` with proper authorization via `viewOwn` policy
- Add route `/v1/medication-appointments/history`
- Add 8 comprehensive feature tests

### Mobile (React Native/Expo)
- Create `history.tsx` screen with FlatList, pull-to-refresh, and empty state
- Add `listHistory()` to `medicationAppointmentService`
- Add `fetchHistory()` action and `history` state to `medicationAppointmentStore`
- Add "Histórico" tab with clock icon to receptor tab navigation

### Seeders
- Create `MedicationHistorySeeder` that adds 3 completed appointments:
  - Novalgina 1g (received 30 days ago)
  - Paracetamol 750mg (received 14 days ago)
  - Ibuprofeno 600mg (received 7 days ago)

---

## Como Testar Manualmente

### Preparar o Ambiente

**Terminal 1 - Backend:**
```bash
cd web
composer install
php artisan migrate:fresh --seed
php artisan serve
```

Após o seed, você verá:
```
===== DADOS DE ACESSO =====
Médico:
  Email: doctor@example.com
  Senha: password
Receptor (Paciente):
  Email: receptor@example.com
  Senha: password
===========================
Created 3 completed appointments for medication history.
```

**Terminal 2 - Mobile:**
```bash
cd mobile
npm install
npm start
```

### Passos para Testar

1. Abrir o app mobile (Expo Go)
2. Fazer login como **receptor@example.com / password**
3. Na barra de navegação inferior, clicar na aba **"Histórico"** (ícone de relógio)
4. Verificar que a tela exibe 3 medicamentos recebidos:
   - Ibuprofeno 600mg (mais recente - 7 dias atrás)
   - Paracetamol 750mg (14 dias atrás)
   - Novalgina 1g (30 dias atrás)

### Cenários a Validar

- [x] **Com dados:** Exibe lista com nome, substância, laboratório, lote, validade, doador e data
- [x] **Ordenação:** Mais recente primeiro (Ibuprofeno → Paracetamol → Novalgina)
- [ ] **Pull-to-refresh:** Puxar para baixo atualiza a lista
- [ ] **Loading:** Indicador de carregamento aparece ao iniciar

### Para testar estado vazio

```bash
# Criar um receptor sem histórico
cd web
php artisan tinker
>>> \App\Models\User::factory()->receptor()->create(['email' => 'novo@test.com', 'password' => bcrypt('password')])
```
Faça login com `novo@test.com / password` e veja a mensagem "Nenhum medicamento recebido".

---

## Arquivos Modificados

| Arquivo | Descrição |
|---------|-----------|
| `web/routes/api.php:83` | Nova rota `/history` |
| `web/app/Actions/MedicationAppointment/ListReceptorHistoryAction.php` | Lógica de busca |
| `web/database/seeders/MedicationHistorySeeder.php` | Seeder de dados de teste |
| `web/database/seeders/DatabaseSeeder.php` | Atualizado para incluir history seeder |
| `mobile/app/(auth)/receptor/(tabs)/history.tsx` | Tela de histórico |
| `mobile/app/(auth)/receptor/(tabs)/_layout.tsx:57-66` | Configuração da aba |

---

## Test plan
- [x] Backend: All 332 tests passing (8 new)
- [x] Mobile: ESLint passing
- [ ] Manual: Test history screen shows 3 medications after seed
- [ ] Manual: Test empty state with new receptor user
- [ ] Manual: Test pull-to-refresh functionality

Closes #51