### PR TITLE
feat: add doctor donation history screen

### DIFF
--- a/mobile/app/(auth)/dashboard.tsx
+++ b/mobile/app/(auth)/dashboard.tsx
@@ -31,6 +31,10 @@ export default function Dashboard() {
     router.push('/(auth)/medication-appointments');
   };
 
+  const handleDonationHistory = () => {
+    router.push('/(auth)/doctor/history');
+  };
+
   // Receptor navigation
   const handleSearchMedications = () => {
     router.push('/(auth)/receptor/search');
@@ -60,6 +64,7 @@ export default function Dashboard() {
             />
             <SecondaryButton label="Solicitações Recebidas" onPress={handleReceivedRequests} />
             <SecondaryButton label="Agendamentos" onPress={handleReceivedAppointments} />
+            <SecondaryButton label="Histórico de Doações" onPress={handleDonationHistory} />
           </>
         )}
 

--- a/mobile/app/(auth)/doctor/history.tsx
+++ b/mobile/app/(auth)/doctor/history.tsx
@@ -1,0 +1,316 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
+import { useMedicationAppointmentStore } from '@/stores/medicationAppointmentStore';
+import { Colors } from '@/constants/Colors';
+import { MedicationAppointment } from '@/types/medicationAppointment';
+
+export default function DoctorHistoryScreen() {
+  const { donationHistory, isLoading, error, fetchDoctorHistory, clearError } =
+    useMedicationAppointmentStore();
+
+  useEffect(() => {
+    fetchDoctorHistory();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    });
+  };
+
+  const renderItem = ({ item }: { item: MedicationAppointment }) => {
+    const drug = item.medication_request?.medication_offering?.drug;
+    const receptor = item.medication_request?.receptor;
+
+    return (
+      <View style={styles.card}>
+        <View style={styles.cardHeader}>
+          <Text style={styles.medicationName}>{drug?.product_name || 'Medicamento'}</Text>
+          <View style={styles.statusBadge}>
+            <Text style={styles.statusText}>Doado</Text>
+          </View>
+        </View>
+
+        <View style={styles.cardContent}>
+          {drug?.substance && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Substância:</Text>
+              <Text style={styles.infoValue}>{drug.substance}</Text>
+            </View>
+          )}
+
+          {drug?.laboratory && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Laboratório:</Text>
+              <Text style={styles.infoValue}>{drug.laboratory}</Text>
+            </View>
+          )}
+
+          {item.medication_request?.medication_offering?.lot_number && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Lote:</Text>
+              <Text style={styles.infoValue}>
+                {item.medication_request.medication_offering.lot_number}
+              </Text>
+            </View>
+          )}
+
+          {item.medication_request?.medication_offering?.expires_at && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Validade:</Text>
+              <Text style={styles.infoValue}>
+                {formatDate(item.medication_request.medication_offering.expires_at)}
+              </Text>
+            </View>
+          )}
+
+          {receptor?.name && (
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Beneficiário:</Text>
+              <Text style={styles.infoValue}>{receptor.name}</Text>
+            </View>
+          )}
+
+          <View style={styles.divider} />
+
+          <View style={styles.dateRow}>
+            <Text style={styles.dateIcon}>📅</Text>
+            <Text style={styles.dateText}>Doado em {formatDate(item.updated_at)}</Text>
+          </View>
+        </View>
+      </View>
+    );
+  };
+
+  const renderEmpty = () => {
+    if (isLoading) return null;
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyIcon}>🎁</Text>
+        <Text style={styles.emptyTitle}>Nenhuma doação realizada</Text>
+        <Text style={styles.emptyText}>
+          Quando você concluir doações de medicamentos, elas aparecerão aqui.
+        </Text>
+        <Text style={styles.emptyHint}>
+          Cadastre ofertas de medicamentos para começar a ajudar quem precisa.
+        </Text>
+      </View>
+    );
+  };
+
+  if (error) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorIcon}>⚠️</Text>
+        <Text style={styles.errorText}>{error}</Text>
+        <Text
+          style={styles.retryText}
+          onPress={() => {
+            clearError();
+            fetchDoctorHistory();
+          }}
+        >
+          Tentar novamente
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Header info */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Seu histórico de doações</Text>
+        <Text style={styles.headerSubtitle}>
+          {donationHistory.length}{' '}
+          {donationHistory.length === 1 ? 'doação realizada' : 'doações realizadas'}
+        </Text>
+      </View>
+
+      {isLoading && donationHistory.length === 0 ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.yellow_green_500} />
+          <Text style={styles.loadingText}>Carregando histórico...</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={donationHistory}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={isLoading}
+              onRefresh={fetchDoctorHistory}
+              colors={[Colors.yellow_green_500]}
+              tintColor={Colors.yellow_green_500}
+            />
+          }
+          ListEmptyComponent={renderEmpty}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f3f4f6',
+  },
+  header: {
+    backgroundColor: '#ffffff',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: '#6b7280',
+    marginTop: 4,
+  },
+  listContent: {
+    padding: 16,
+    flexGrow: 1,
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 2,
+    overflow: 'hidden',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: '#eff6ff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#dbeafe',
+  },
+  medicationName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2937',
+    flex: 1,
+    marginRight: 8,
+  },
+  statusBadge: {
+    backgroundColor: '#3b82f6',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  statusText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  cardContent: {
+    padding: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    marginBottom: 8,
+  },
+  infoLabel: {
+    fontSize: 14,
+    color: '#6b7280',
+    width: 100,
+  },
+  infoValue: {
+    fontSize: 14,
+    color: '#1f2937',
+    flex: 1,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#e5e7eb',
+    marginVertical: 12,
+  },
+  dateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  dateIcon: {
+    fontSize: 16,
+    marginRight: 8,
+  },
+  dateText: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  emptyIcon: {
+    fontSize: 64,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#1f2937',
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#6b7280',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  emptyHint: {
+    fontSize: 14,
+    color: '#9ca3af',
+    textAlign: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  errorIcon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#ef4444',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  retryText: {
+    fontSize: 16,
+    color: Colors.yellow_green_500,
+    fontWeight: '600',
+  },
+});

--- a/mobile/services/medicationAppointmentService.ts
+++ b/mobile/services/medicationAppointmentService.ts
@@ -110,4 +110,16 @@ export const medicationAppointmentService = {
       throw new Error(extractErrorMessage(error));
     }
   },
+
+  /**
+   * List doctor's donation history (completed appointments)
+   */
+  listDoctorHistory: async (): Promise<MedicationAppointment[]> => {
+    try {
+      const response = await api.get('/v1/medication-appointments/doctor-history');
+      return response.data.data;
+    } catch (error: any) {
+      throw new Error(extractErrorMessage(error));
+    }
+  },
 };

--- a/mobile/stores/medicationAppointmentStore.ts
+++ b/mobile/stores/medicationAppointmentStore.ts
@@ -14,6 +14,8 @@ interface MedicationAppointmentStoreState {
   receivedAppointments: MedicationAppointment[];
   // Receptor's medication history (completed appointments)
   history: MedicationAppointment[];
+  // Doctor's donation history (completed appointments)
+  donationHistory: MedicationAppointment[];
   isLoading: boolean;
   error: string | null;
 
@@ -26,6 +28,7 @@ interface MedicationAppointmentStoreState {
   // Doctor actions
   fetchReceivedAppointments: (status?: MedicationAppointmentStatus) => Promise<void>;
   confirmDeliveryDoctor: (id: number) => Promise<void>;
+  fetchDoctorHistory: () => Promise<void>;
 
   // Negotiation actions (both roles)
   acceptAppointment: (id: number, isDoctor: boolean) => Promise<void>;
@@ -42,6 +45,7 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
   appointments: [],
   receivedAppointments: [],
   history: [],
+  donationHistory: [],
   isLoading: false,
   error: null,
 
@@ -122,6 +126,17 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
         isLoading: false,
         error: null,
       }));
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false });
+      throw error;
+    }
+  },
+
+  fetchDoctorHistory: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const donationHistory = await medicationAppointmentService.listDoctorHistory();
+      set({ donationHistory, isLoading: false, error: null });
     } catch (error: any) {
       set({ error: error.message, isLoading: false });
       throw error;

--- a/web/app/Actions/MedicationAppointment/ListDoctorDonationHistoryAction.php
+++ b/web/app/Actions/MedicationAppointment/ListDoctorDonationHistoryAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\MedicationAppointment;
+
+use App\Models\Doctor;
+use App\Models\MedicationAppointment;
+use Illuminate\Database\Eloquent\Collection;
+
+class ListDoctorDonationHistoryAction
+{
+    /**
+     * Execute the action to list doctor's completed donations (history).
+     *
+     * @return Collection<int, MedicationAppointment>
+     */
+    public function execute(Doctor $doctor): Collection
+    {
+        return MedicationAppointment::query()
+            ->whereHas('medicationRequest.medicationOffering', fn ($q) => $q->where('doctor_id', $doctor->id))
+            ->completed()
+            ->with([
+                'medicationRequest.medicationOffering.drug',
+                'medicationRequest.receptor',
+                'address',
+            ])
+            ->orderByDesc('updated_at')
+            ->get();
+    }
+}

--- a/web/app/Http/Controllers/Api/V1/MedicationAppointment/DoctorHistoryController.php
+++ b/web/app/Http/Controllers/Api/V1/MedicationAppointment/DoctorHistoryController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\MedicationAppointment;
+
+use App\Actions\MedicationAppointment\ListDoctorDonationHistoryAction;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\MedicationAppointmentResource;
+use App\Models\MedicationAppointment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class DoctorHistoryController extends Controller
+{
+    /**
+     * Handle the incoming request to list doctor's donation history.
+     */
+    public function __invoke(
+        Request $request,
+        ListDoctorDonationHistoryAction $action
+    ): AnonymousResourceCollection {
+        $this->authorize('viewDonationHistory', MedicationAppointment::class);
+
+        $appointments = $action->execute($request->user()->doctor);
+
+        return MedicationAppointmentResource::collection($appointments);
+    }
+}

--- a/web/app/Policies/MedicationAppointmentPolicy.php
+++ b/web/app/Policies/MedicationAppointmentPolicy.php
@@ -40,6 +40,15 @@ class MedicationAppointmentPolicy
     }
 
     /**
+     * Determine whether the user can view their donation history.
+     * Only doctors can view their donation history.
+     */
+    public function viewDonationHistory(User $user): bool
+    {
+        return $user->role === 'doctor' && $user->doctor !== null;
+    }
+
+    /**
      * Determine whether the receptor can confirm delivery.
      * Note: Status checks (completed, already confirmed) are done in the controller as business rules.
      */

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -84,6 +84,8 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.medication-appointments.store');
         Route::get('/history', MedicationAppointment\HistoryController::class)
             ->name('api.v1.medication-appointments.history');
+        Route::get('/doctor-history', MedicationAppointment\DoctorHistoryController::class)
+            ->name('api.v1.medication-appointments.doctor-history');
         Route::get('/received', MedicationAppointment\ReceivedController::class)
             ->name('api.v1.medication-appointments.received');
         Route::patch(

--- a/web/tests/Feature/Api/V1/MedicationAppointment/DoctorHistoryTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/DoctorHistoryTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\Address;
+use App\Models\Doctor;
+use App\Models\MedicationAppointment;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+// Happy Path Tests
+
+it('should return list of completed donations (doctor history)', function (): void {
+    $receptor = User::factory()->receptor()->create();
+    $doctor   = Doctor::factory()->create();
+    $address  = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $request  = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering)
+        ->confirmed()
+        ->create();
+    $appointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/medication-appointments/doctor-history');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $appointment->id)
+        ->assertJsonPath('data.0.status', 'completed');
+});
+
+it('should return doctor history with correct structure including drug and receptor info', function (): void {
+    $receptor = User::factory()->receptor()->create();
+    $doctor   = Doctor::factory()->create();
+    $address  = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $request  = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering)
+        ->confirmed()
+        ->create();
+    MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/medication-appointments/doctor-history');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'scheduled_date',
+                    'scheduled_time',
+                    'status',
+                    'receptor_confirmed',
+                    'doctor_confirmed',
+                    'medication_request' => [
+                        'id',
+                        'status',
+                        'receptor' => [
+                            'id',
+                            'name',
+                        ],
+                        'medication_offering' => [
+                            'id',
+                            'quantity',
+                            'lot_number',
+                            'expires_at',
+                            'status',
+                            'drug' => [
+                                'id',
+                                'product_name',
+                                'substance',
+                                'presentation',
+                                'laboratory',
+                            ],
+                        ],
+                    ],
+                    'address',
+                ],
+            ],
+        ]);
+});
+
+it('should return empty list when doctor has no completed donations', function (): void {
+    $doctor = Doctor::factory()->create();
+
+    actingAs($doctor->user);
+
+    getJson('/api/v1/medication-appointments/doctor-history')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('should only return completed appointments, not proposed or confirmed', function (): void {
+    $receptor  = User::factory()->receptor()->create();
+    $doctor    = Doctor::factory()->create();
+    $address   = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering1 = MedicationOffering::factory()->reserved()->create(['doctor_id' => $doctor->id]);
+    $offering2 = MedicationOffering::factory()->reserved()->create(['doctor_id' => $doctor->id]);
+    $offering3 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+
+    $request1 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering1)
+        ->confirmed()
+        ->create();
+    $request2 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering2)
+        ->confirmed()
+        ->create();
+    $request3 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering3)
+        ->confirmed()
+        ->create();
+
+    // Proposed appointment - should NOT appear in history
+    MedicationAppointment::factory()->proposed()->create([
+        'medication_request_id' => $request1->id,
+        'address_id'            => $address->id,
+    ]);
+    // Confirmed appointment - should NOT appear in history
+    MedicationAppointment::factory()->confirmed()->create([
+        'medication_request_id' => $request2->id,
+        'address_id'            => $address->id,
+    ]);
+    // Completed appointment - should appear in history
+    $completedAppointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request3->id,
+        'address_id'            => $address->id,
+    ]);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/medication-appointments/doctor-history');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $completedAppointment->id);
+});
+
+it('should only return own completed donations', function (): void {
+    $receptor  = User::factory()->receptor()->create();
+    $doctor1   = Doctor::factory()->create();
+    $doctor2   = Doctor::factory()->create();
+    $address1  = Address::factory()->create(['user_id' => $doctor1->user->id]);
+    $address2  = Address::factory()->create(['user_id' => $doctor2->user->id]);
+    $offering1 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor1->id]);
+    $offering2 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor2->id]);
+
+    $request1 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering1)
+        ->confirmed()
+        ->create();
+    $request2 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering2)
+        ->confirmed()
+        ->create();
+
+    $apt1 = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request1->id,
+        'address_id'            => $address1->id,
+    ]);
+    MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request2->id,
+        'address_id'            => $address2->id,
+    ]);
+
+    actingAs($doctor1->user);
+
+    $response = getJson('/api/v1/medication-appointments/doctor-history');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $apt1->id);
+});
+
+it('should return history sorted by completion date (most recent first)', function (): void {
+    $receptor  = User::factory()->receptor()->create();
+    $doctor    = Doctor::factory()->create();
+    $address   = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering1 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $offering2 = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+
+    $request1 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering1)
+        ->confirmed()
+        ->create();
+    $request2 = MedicationRequest::factory()
+        ->forReceptor($receptor)
+        ->forOffering($offering2)
+        ->confirmed()
+        ->create();
+
+    // Older completed donation
+    $apt1 = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request1->id,
+        'address_id'            => $address->id,
+        'updated_at'            => now()->subDays(5),
+    ]);
+    // More recent completed donation
+    $apt2 = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request2->id,
+        'address_id'            => $address->id,
+        'updated_at'            => now()->subDays(2),
+    ]);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/medication-appointments/doctor-history');
+
+    $response->assertOk()
+        ->assertJsonPath('data.0.id', $apt2->id)
+        ->assertJsonPath('data.1.id', $apt1->id);
+});
+
+// Authorization Error Tests
+
+it('should return 401 for unauthenticated users', function (): void {
+    getJson('/api/v1/medication-appointments/doctor-history')
+        ->assertUnauthorized();
+});
+
+it('should return 403 when receptor tries to access doctor history', function (): void {
+    $receptor = User::factory()->receptor()->create();
+
+    actingAs($receptor);
+
+    getJson('/api/v1/medication-appointments/doctor-history')
+        ->assertForbidden();
+});


### PR DESCRIPTION
## Descrição

Implementa a funcionalidade de histórico de doações para médicos, permitindo que eles acompanhem o impacto de suas doações na plataforma.

**Issue:** Closes #53

## Mudanças

### Backend (API)
- **Action:** `ListDoctorDonationHistoryAction` - busca agendamentos concluídos onde o médico foi o doador
- **Controller:** `DoctorHistoryController` - expõe endpoint `GET /v1/medication-appointments/doctor-history`
- **Policy:** Adiciona método `viewDonationHistory` para autorização
- **Testes:** 8 testes de feature cobrindo cenários de sucesso e autorização

### Mobile
- **Service:** Adiciona `listDoctorHistory` ao `medicationAppointmentService`
- **Store:** Adiciona `fetchDoctorHistory` action e `donationHistory` state
- **Tela:** Nova tela `DoctorHistoryScreen` em `/app/(auth)/doctor/history.tsx`
- **Dashboard:** Adiciona botão "Histórico de Doações" no painel do médico

## Dados exibidos no histórico
- Nome do medicamento
- Substância e laboratório
- Lote e validade
- Nome do beneficiário (receptor)
- Data da doação

## Testes
- [x] Backend: 340 testes passando (8 novos testes para o endpoint)
- [x] Mobile: Lint passando
- [x] PHPStan: Sem erros

## Screenshots
A tela segue o mesmo padrão visual da tela de histórico do receptor, com card azul para identificar doações realizadas.