### PR TITLE
feat(api): notify doctor when receptor requests medication

### DIFF
--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -64,7 +64,8 @@ O sistema de push notifications do DoaFarma permite enviar lembretes nativos (co
 | **RegisterPushTokenAction** | `app/Actions/PushToken/RegisterPushTokenAction.php` | Lógica de registro (upsert) |
 | **RegisterController** | `app/Http/Controllers/V1/PushToken/RegisterController.php` | Endpoint POST /push-tokens |
 | **DeleteController** | `app/Http/Controllers/V1/PushToken/DeleteController.php` | Endpoint DELETE /push-tokens |
-| **SendAppointmentReminderJob** | `app/Jobs/SendAppointmentReminderJob.php` | Envia notificação via Expo API |
+| **SendAppointmentReminderJob** | `app/Jobs/SendAppointmentReminderJob.php` | Envia lembrete de agendamento via Expo API |
+| **NotifyDoctorNewRequestJob** | `app/Jobs/NotifyDoctorNewRequestJob.php` | Notifica médico sobre nova solicitação |
 | **SendAppointmentRemindersCommand** | `app/Console/Commands/SendAppointmentRemindersCommand.php` | Busca agendamentos e dispara jobs |
 
 ### Mobile (React Native/Expo)
@@ -175,12 +176,26 @@ addNotificationResponseReceivedListener((response) => {
 });
 ```
 
-## Lembretes Enviados
+## Tipos de Notificações
 
-| Momento | Janela de Envio | Mensagem |
-|---------|-----------------|----------|
-| 24h antes | 23:55 a 24:05 antes do horário | "Você tem um agendamento amanhã às HH:MM..." |
-| 1h antes | 0:55 a 1:05 antes do horário | "Você tem um agendamento em 1 hora..." |
+### 1. Lembrete de Agendamento
+
+| Momento | Janela de Envio | Destinatário | Mensagem |
+|---------|-----------------|--------------|----------|
+| 24h antes | 23:55 a 24:05 antes do horário | Receptor e Médico | "Você tem um agendamento amanhã às HH:MM..." |
+| 1h antes | 0:55 a 1:05 antes do horário | Receptor e Médico | "Você tem um agendamento em 1 hora..." |
+
+**Job:** `SendAppointmentReminderJob`
+**Trigger:** Scheduler (a cada 5 minutos)
+
+### 2. Nova Solicitação de Medicamento
+
+| Evento | Destinatário | Mensagem |
+|--------|--------------|----------|
+| Receptor solicita medicamento | Médico (dono da oferta) | "Nova solicitação de medicamento: [Receptor] solicitou o medicamento [Medicamento]" |
+
+**Job:** `NotifyDoctorNewRequestJob`
+**Trigger:** Ao criar um `MedicationRequest` (via `CreateMedicationRequestAction`)
 
 ## Testes Manuais
 

--- a/web/app/Actions/MedicationRequest/CreateMedicationRequestAction.php
+++ b/web/app/Actions/MedicationRequest/CreateMedicationRequestAction.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace App\Actions\MedicationRequest;
 
+use App\Jobs\NotifyDoctorNewRequestJob;
 use App\Models\MedicationOffering;
 use App\Models\MedicationRequest;
 use App\Models\User;
@@ -22,7 +23,7 @@ class CreateMedicationRequestAction
      */
     public function execute(int $medicationOfferingId, User $receptor): MedicationRequest
     {
-        return DB::transaction(function () use ($medicationOfferingId, $receptor): MedicationRequest {
+        $request = DB::transaction(function () use ($medicationOfferingId, $receptor): MedicationRequest {
             // Lock the offering row to prevent race conditions
             $offering = MedicationOffering::lockForUpdate()->findOrFail($medicationOfferingId);
 
@@ -32,7 +33,7 @@ class CreateMedicationRequestAction
             }
 
             // Create the request
-            $request = MedicationRequest::create([
+            $medicationRequest = MedicationRequest::create([
                 'receptor_id'            => $receptor->id,
                 'medication_offering_id' => $offering->id,
                 'status'                 => 'pending',
@@ -42,9 +43,14 @@ class CreateMedicationRequestAction
             $offering->update(['status' => 'reserved']);
 
             // Load relationships for the response
-            $request->load(['medicationOffering.drug', 'medicationOffering.doctor.user', 'receptor']);
+            $medicationRequest->load(['medicationOffering.drug', 'medicationOffering.doctor.user', 'receptor']);
 
-            return $request;
+            return $medicationRequest;
         });
+
+        // Dispatch notification job after transaction commits
+        NotifyDoctorNewRequestJob::dispatch($request->id);
+
+        return $request;
     }
 }

--- a/web/app/Jobs/NotifyDoctorNewRequestJob.php
+++ b/web/app/Jobs/NotifyDoctorNewRequestJob.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Jobs;
+
+use App\Models\MedicationRequest;
+use App\Models\PushToken;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class NotifyDoctorNewRequestJob implements ShouldQueue
+{
+    use Queueable;
+
+    private const string EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
+
+    public function __construct(
+        private readonly int $medicationRequestId,
+    ) {
+        //
+    }
+
+    public function handle(): void
+    {
+        $request = MedicationRequest::with([
+            'receptor',
+            'medicationOffering.doctor.user',
+            'medicationOffering.drug',
+        ])->find($this->medicationRequestId);
+
+        if (! $request) {
+            Log::warning('MedicationRequest not found for notification', [
+                'medication_request_id' => $this->medicationRequestId,
+            ]);
+
+            return;
+        }
+
+        // Only notify for pending requests
+        if ($request->status !== 'pending') {
+            Log::info('Skipping notification for non-pending request', [
+                'medication_request_id' => $this->medicationRequestId,
+                'status'                => $request->status,
+            ]);
+
+            return;
+        }
+
+        $this->sendNotificationToDoctor($request);
+    }
+
+    private function sendNotificationToDoctor(MedicationRequest $request): void
+    {
+        $doctor = $request->medicationOffering->doctor;
+
+        if (! $doctor || ! $doctor->user) {
+            Log::warning('Doctor or doctor user not found for notification', [
+                'medication_request_id' => $request->id,
+            ]);
+
+            return;
+        }
+
+        $tokens = PushToken::where('user_id', $doctor->user->id)->pluck('token')->toArray();
+
+        if (empty($tokens)) {
+            Log::info('No push tokens for doctor', ['user_id' => $doctor->user->id]);
+
+            return;
+        }
+
+        $receptorName = $request->receptor->name;
+        $drugName     = $request->medicationOffering->drug->product_name;
+
+        $title = 'Nova solicitação de medicamento';
+        $body  = sprintf(
+            '%s solicitou o medicamento %s',
+            $receptorName,
+            $drugName
+        );
+
+        $this->sendPushNotification($tokens, $title, $body, [
+            'type'                  => 'new_medication_request',
+            'medication_request_id' => $request->id,
+        ]);
+    }
+
+    /**
+     * @param array<string> $tokens
+     * @param array<string, mixed> $data
+     */
+    private function sendPushNotification(array $tokens, string $title, string $body, array $data = []): void
+    {
+        $messages = [];
+
+        foreach ($tokens as $token) {
+            $messages[] = [
+                'to'    => $token,
+                'sound' => 'default',
+                'title' => $title,
+                'body'  => $body,
+                'data'  => $data,
+            ];
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'Accept'       => 'application/json',
+                'Content-Type' => 'application/json',
+            ])->post(self::EXPO_PUSH_URL, $messages);
+
+            if ($response->successful()) {
+                Log::info('Push notification sent successfully to doctor', [
+                    'tokens_count' => count($tokens),
+                    'title'        => $title,
+                ]);
+            } else {
+                Log::error('Failed to send push notification to doctor', [
+                    'status'   => $response->status(),
+                    'response' => $response->json(),
+                ]);
+            }
+        } catch (\Exception $e) {
+            Log::error('Exception sending push notification to doctor', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/web/tests/Feature/Api/V1/MedicationRequest/StoreTest.php
+++ b/web/tests/Feature/Api/V1/MedicationRequest/StoreTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types = 1);
 
+use App\Jobs\NotifyDoctorNewRequestJob;
 use App\Models\Doctor;
 use App\Models\MedicationOffering;
 use App\Models\MedicationRequest;
 use App\Models\User;
+use Illuminate\Support\Facades\Queue;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
@@ -215,4 +217,45 @@ it('should allow requesting an offering that was previously rejected', function 
     ])->assertCreated();
 
     expect(MedicationRequest::count())->toBe(2);
+});
+
+// Notification Tests
+
+it('should dispatch NotifyDoctorNewRequestJob when creating a request', function (): void {
+    Queue::fake();
+
+    $receptor = User::factory()->receptor()->create();
+    $offering = MedicationOffering::factory()->available()->create();
+
+    actingAs($receptor);
+
+    postJson('/api/v1/medication-requests', [
+        'medication_offering_id' => $offering->id,
+    ])->assertCreated();
+
+    Queue::assertPushed(NotifyDoctorNewRequestJob::class, fn ($job): true => true);
+});
+
+it('should dispatch notification with correct request id', function (): void {
+    Queue::fake();
+
+    $receptor = User::factory()->receptor()->create();
+    $offering = MedicationOffering::factory()->available()->create();
+
+    actingAs($receptor);
+
+    postJson('/api/v1/medication-requests', [
+        'medication_offering_id' => $offering->id,
+    ])->assertCreated();
+
+    $createdRequest = MedicationRequest::first();
+
+    Queue::assertPushed(NotifyDoctorNewRequestJob::class, function ($job) use ($createdRequest): bool {
+        // Use reflection to access the private property
+        $reflection = new ReflectionClass($job);
+        $property   = $reflection->getProperty('medicationRequestId');
+        $requestId  = $property->getValue($job);
+
+        return $requestId === $createdRequest->id;
+    });
 });

--- a/web/tests/Unit/Jobs/NotifyDoctorNewRequestJobTest.php
+++ b/web/tests/Unit/Jobs/NotifyDoctorNewRequestJobTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Jobs\NotifyDoctorNewRequestJob;
+use App\Models\MedicationRequest;
+use App\Models\PushToken;
+use Illuminate\Support\Facades\Http;
+
+it('should not send notification for non-existent request', function (): void {
+    Http::fake();
+
+    $job = new NotifyDoctorNewRequestJob(999);
+    $job->handle();
+
+    Http::assertNothingSent();
+});
+
+it('should not send notification for non-pending request', function (): void {
+    Http::fake();
+
+    $request = MedicationRequest::factory()
+        ->confirmed()
+        ->create();
+
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    Http::assertNothingSent();
+});
+
+it('should send notification to doctor when has token', function (): void {
+    Http::fake([
+        'https://exp.host/--/api/v2/push/send' => Http::response(['data' => []], 200),
+    ]);
+
+    $request = MedicationRequest::factory()
+        ->pending()
+        ->create();
+
+    // Create push token for doctor
+    $doctorUserId = $request->medicationOffering->doctor->user_id;
+    PushToken::factory()->create(['user_id' => $doctorUserId]);
+
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    Http::assertSentCount(1);
+});
+
+it('should not send notification if doctor has no push tokens', function (): void {
+    Http::fake();
+
+    $request = MedicationRequest::factory()
+        ->pending()
+        ->create();
+
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    Http::assertNothingSent();
+});
+
+it('should include correct title and body in notification', function (): void {
+    Http::fake([
+        'https://exp.host/--/api/v2/push/send' => Http::response(['data' => []], 200),
+    ]);
+
+    $request = MedicationRequest::factory()
+        ->pending()
+        ->create();
+
+    $doctorUserId = $request->medicationOffering->doctor->user_id;
+    PushToken::factory()->create(['user_id' => $doctorUserId, 'token' => 'test-token']);
+
+    $receptorName = $request->receptor->name;
+    $drugName     = $request->medicationOffering->drug->product_name;
+
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    Http::assertSent(function ($httpRequest) use ($receptorName, $drugName): bool {
+        $body = $httpRequest->data();
+
+        return isset($body[0]['title'])
+            && $body[0]['title'] === 'Nova solicitação de medicamento'
+            && isset($body[0]['body'])
+            && str_contains((string) $body[0]['body'], (string) $receptorName)
+            && str_contains((string) $body[0]['body'], (string) $drugName);
+    });
+});
+
+it('should include correct data in notification payload', function (): void {
+    Http::fake([
+        'https://exp.host/--/api/v2/push/send' => Http::response(['data' => []], 200),
+    ]);
+
+    $request = MedicationRequest::factory()
+        ->pending()
+        ->create();
+
+    $doctorUserId = $request->medicationOffering->doctor->user_id;
+    PushToken::factory()->create(['user_id' => $doctorUserId]);
+
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    Http::assertSent(function ($httpRequest) use ($request): bool {
+        $body = $httpRequest->data();
+
+        return isset($body[0]['data']['type'])
+            && $body[0]['data']['type'] === 'new_medication_request'
+            && isset($body[0]['data']['medication_request_id'])
+            && $body[0]['data']['medication_request_id'] === $request->id;
+    });
+});
+
+it('should handle failed push notification gracefully', function (): void {
+    Http::fake([
+        'https://exp.host/--/api/v2/push/send' => Http::response(['error' => 'Server error'], 500),
+    ]);
+
+    $request = MedicationRequest::factory()
+        ->pending()
+        ->create();
+
+    $doctorUserId = $request->medicationOffering->doctor->user_id;
+    PushToken::factory()->create(['user_id' => $doctorUserId]);
+
+    // Should not throw exception even when API fails
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    expect(true)->toBeTrue();
+});
+
+it('should send to multiple tokens for same doctor', function (): void {
+    Http::fake([
+        'https://exp.host/--/api/v2/push/send' => Http::response(['data' => []], 200),
+    ]);
+
+    $request = MedicationRequest::factory()
+        ->pending()
+        ->create();
+
+    $doctorUserId = $request->medicationOffering->doctor->user_id;
+
+    // Create multiple tokens for the same doctor
+    PushToken::factory()->count(3)->create(['user_id' => $doctorUserId]);
+
+    $job = new NotifyDoctorNewRequestJob($request->id);
+    $job->handle();
+
+    // Should send to all 3 tokens in a single request
+    Http::assertSent(function ($httpRequest): bool {
+        $body = $httpRequest->data();
+
+        return count($body) === 3;
+    });
+});


### PR DESCRIPTION
## Descrição

Implementa o sistema de notificação push para médicos quando um receptor solicita um medicamento.

**Issue:** Closes #57

## O que foi feito

### Backend (Laravel)
- **NotifyDoctorNewRequestJob**: Novo Job que envia push notification ao médico dono da oferta
  - Busca tokens de push do médico
  - Envia notificação com título "Nova solicitação de medicamento"
  - Inclui nome do receptor e do medicamento no corpo
  - Trata graciosamente falhas na API do Expo
  
- **CreateMedicationRequestAction**: Modificado para disparar o job após criar a solicitação
  - Job é disparado após o commit da transação para garantir consistência

### Testes
- 8 testes unitários para o novo Job
- 2 testes de integração para verificar que o Job é disparado corretamente

### Documentação
- Atualizado `docs/PUSH_NOTIFICATIONS.md` com o novo tipo de notificação

## Arquivos modificados

- `web/app/Jobs/NotifyDoctorNewRequestJob.php` (novo)
- `web/app/Actions/MedicationRequest/CreateMedicationRequestAction.php`
- `web/tests/Unit/Jobs/NotifyDoctorNewRequestJobTest.php` (novo)
- `web/tests/Feature/Api/V1/MedicationRequest/StoreTest.php`
- `docs/PUSH_NOTIFICATIONS.md`

## Como Testar Manualmente

### Pré-requisitos
- Backend rodando: `cd web && php artisan serve`
- Queue worker rodando: `cd web && php artisan queue:work`
- Mobile rodando em dispositivo físico: `cd mobile && npm start`
- Médico e receptor com push tokens registrados

### Passos para Testar
1. Fazer login como médico e cadastrar uma oferta de medicamento
2. Verificar que o médico tem token de push registrado (`push_tokens` table)
3. Fazer login como receptor em outro dispositivo
4. Buscar e solicitar o medicamento
5. O médico deve receber uma notificação push

### Cenários a Validar
- [x] Médico recebe notificação quando receptor solicita
- [x] Notificação contém nome do receptor e medicamento
- [x] Funciona com múltiplos tokens do mesmo médico
- [x] Não quebra se médico não tiver token

## Testes

- ✅ PHPStan: Sem erros
- ✅ Pest: 369 testes passando (10 novos)
- ✅ Laravel Pint: Código formatado