### PR TITLE
feat: implement doctor ratings view

### DIFF
--- a/mobile/app/(auth)/dashboard.tsx
+++ b/mobile/app/(auth)/dashboard.tsx
@@ -35,6 +35,10 @@ export default function Dashboard() {
     router.push('/(auth)/doctor/history');
   };
 
+  const handleMyRatings = () => {
+    router.push('/(auth)/doctor/ratings');
+  };
+
   // Receptor navigation
   const handleSearchMedications = () => {
     router.push('/(auth)/receptor/search');
@@ -65,6 +69,7 @@ export default function Dashboard() {
             <SecondaryButton label="Solicitações Recebidas" onPress={handleReceivedRequests} />
             <SecondaryButton label="Agendamentos" onPress={handleReceivedAppointments} />
             <SecondaryButton label="Histórico de Doações" onPress={handleDonationHistory} />
+            <SecondaryButton label="Minhas Avaliações" onPress={handleMyRatings} />
           </>
         )}
 

--- a/mobile/app/(auth)/doctor/ratings.tsx
+++ b/mobile/app/(auth)/doctor/ratings.tsx
@@ -1,0 +1,341 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
+import { useDoctorRatingStore } from '@/stores/doctorRatingStore';
+import { Colors } from '@/constants/Colors';
+import { DoctorRating, RATING_LABELS } from '@/types/doctorRating';
+
+export default function DoctorRatingsScreen() {
+  const { myRatings, myRatingsSummary, isLoading, error, fetchMyRatings, clearError } =
+    useDoctorRatingStore();
+
+  useEffect(() => {
+    fetchMyRatings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    });
+  };
+
+  const renderStars = (rating: number) => {
+    return (
+      <View style={styles.starsContainer}>
+        {[1, 2, 3, 4, 5].map((star) => (
+          <Text key={star} style={styles.star}>
+            {star <= rating ? '★' : '☆'}
+          </Text>
+        ))}
+      </View>
+    );
+  };
+
+  const renderSummary = () => {
+    if (!myRatingsSummary) return null;
+
+    return (
+      <View style={styles.summaryContainer}>
+        <View style={styles.summaryHeader}>
+          <View style={styles.averageContainer}>
+            <Text style={styles.averageNumber}>{myRatingsSummary.average_rating.toFixed(1)}</Text>
+            {renderStars(Math.round(myRatingsSummary.average_rating))}
+            <Text style={styles.totalRatings}>
+              {myRatingsSummary.total_ratings}{' '}
+              {myRatingsSummary.total_ratings === 1 ? 'avaliacao' : 'avaliacoes'}
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.distributionContainer}>
+          {[5, 4, 3, 2, 1].map((star) => {
+            const count = myRatingsSummary.rating_distribution[star] || 0;
+            const percentage =
+              myRatingsSummary.total_ratings > 0
+                ? (count / myRatingsSummary.total_ratings) * 100
+                : 0;
+
+            return (
+              <View key={star} style={styles.distributionRow}>
+                <Text style={styles.distributionStar}>{star} ★</Text>
+                <View style={styles.barContainer}>
+                  <View style={[styles.barFill, { width: `${percentage}%` }]} />
+                </View>
+                <Text style={styles.distributionCount}>{count}</Text>
+              </View>
+            );
+          })}
+        </View>
+      </View>
+    );
+  };
+
+  const renderItem = ({ item }: { item: DoctorRating }) => {
+    return (
+      <View style={styles.card}>
+        <View style={styles.cardHeader}>
+          <View style={styles.ratingInfo}>
+            {renderStars(item.rating)}
+            <Text style={styles.ratingLabel}>{RATING_LABELS[item.rating]}</Text>
+          </View>
+          <Text style={styles.date}>{formatDate(item.created_at)}</Text>
+        </View>
+
+        {item.comment && <Text style={styles.comment}>{item.comment}</Text>}
+
+        <View style={styles.cardFooter}>
+          <Text style={styles.receptorName}>Por: {item.receptor?.name || 'Anonimo'}</Text>
+        </View>
+      </View>
+    );
+  };
+
+  const renderEmpty = () => {
+    if (isLoading) return null;
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyIcon}>⭐</Text>
+        <Text style={styles.emptyTitle}>Nenhuma avaliacao ainda</Text>
+        <Text style={styles.emptyText}>
+          Quando receptores avaliarem suas doacoes, as avaliacoes aparecerao aqui.
+        </Text>
+        <Text style={styles.emptyHint}>
+          Continue doando medicamentos para receber feedback dos beneficiarios.
+        </Text>
+      </View>
+    );
+  };
+
+  if (error) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorIcon}>⚠️</Text>
+        <Text style={styles.errorText}>{error}</Text>
+        <Text
+          style={styles.retryText}
+          onPress={() => {
+            clearError();
+            fetchMyRatings();
+          }}
+        >
+          Tentar novamente
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {isLoading && myRatings.length === 0 ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.yellow_green_500} />
+          <Text style={styles.loadingText}>Carregando avaliacoes...</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={myRatings}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={renderSummary}
+          refreshControl={
+            <RefreshControl
+              refreshing={isLoading}
+              onRefresh={fetchMyRatings}
+              colors={[Colors.yellow_green_500]}
+              tintColor={Colors.yellow_green_500}
+            />
+          }
+          ListEmptyComponent={renderEmpty}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f3f4f6',
+  },
+  listContent: {
+    padding: 16,
+    flexGrow: 1,
+  },
+  summaryContainer: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  summaryHeader: {
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  averageContainer: {
+    alignItems: 'center',
+  },
+  averageNumber: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    color: '#1f2937',
+  },
+  starsContainer: {
+    flexDirection: 'row',
+    marginTop: 4,
+  },
+  star: {
+    fontSize: 20,
+    color: '#fbbf24',
+  },
+  totalRatings: {
+    fontSize: 14,
+    color: '#6b7280',
+    marginTop: 4,
+  },
+  distributionContainer: {
+    gap: 8,
+  },
+  distributionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  distributionStar: {
+    fontSize: 14,
+    color: '#6b7280',
+    width: 40,
+  },
+  barContainer: {
+    flex: 1,
+    height: 8,
+    backgroundColor: '#e5e7eb',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    backgroundColor: '#fbbf24',
+    borderRadius: 4,
+  },
+  distributionCount: {
+    fontSize: 14,
+    color: '#6b7280',
+    width: 30,
+    textAlign: 'right',
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  ratingInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  ratingLabel: {
+    fontSize: 14,
+    color: '#1f2937',
+    fontWeight: '500',
+  },
+  date: {
+    fontSize: 12,
+    color: '#9ca3af',
+  },
+  comment: {
+    fontSize: 14,
+    color: '#4b5563',
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  cardFooter: {
+    borderTopWidth: 1,
+    borderTopColor: '#f3f4f6',
+    paddingTop: 12,
+  },
+  receptorName: {
+    fontSize: 12,
+    color: '#6b7280',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#6b7280',
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    paddingTop: 64,
+  },
+  emptyIcon: {
+    fontSize: 64,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#1f2937',
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#6b7280',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  emptyHint: {
+    fontSize: 14,
+    color: '#9ca3af',
+    textAlign: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  errorIcon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#ef4444',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  retryText: {
+    fontSize: 16,
+    color: Colors.yellow_green_500,
+    fontWeight: '600',
+  },
+});

--- a/mobile/services/doctorRatingService.ts
+++ b/mobile/services/doctorRatingService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { DoctorRating, CreateDoctorRatingData } from '@/types/doctorRating';
+import { DoctorRating, CreateDoctorRatingData, MyRatingsResponse } from '@/types/doctorRating';
 import { extractErrorMessage } from '@/utils/validation/errorHelpers';
 
 export const doctorRatingService = {
@@ -46,6 +46,18 @@ export const doctorRatingService = {
     try {
       const response = await api.get(`/v1/doctor-ratings/doctor/${doctorId}`);
       return response.data.data;
+    } catch (error: any) {
+      throw new Error(extractErrorMessage(error));
+    }
+  },
+
+  /**
+   * Get authenticated doctor's own ratings with summary statistics
+   */
+  getMyRatings: async (): Promise<MyRatingsResponse> => {
+    try {
+      const response = await api.get('/v1/doctor-ratings/my-ratings');
+      return response.data;
     } catch (error: any) {
       throw new Error(extractErrorMessage(error));
     }

--- a/mobile/stores/doctorRatingStore.ts
+++ b/mobile/stores/doctorRatingStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { doctorRatingService } from '@/services/doctorRatingService';
-import { DoctorRating, CreateDoctorRatingData } from '@/types/doctorRating';
+import { DoctorRating, CreateDoctorRatingData, RatingSummary } from '@/types/doctorRating';
 
 interface DoctorRatingStoreState {
   // Ratings for a specific doctor
@@ -9,6 +9,9 @@ interface DoctorRatingStoreState {
   selectedDoctorId: number | null;
   // Current rating being viewed/edited
   currentRating: DoctorRating | null;
+  // My ratings summary (for doctors)
+  myRatingsSummary: RatingSummary | null;
+  myRatings: DoctorRating[];
   isLoading: boolean;
   error: string | null;
 
@@ -17,15 +20,19 @@ interface DoctorRatingStoreState {
   updateRating: (ratingId: number, data: CreateDoctorRatingData) => Promise<DoctorRating>;
   fetchRatingByAppointment: (appointmentId: number) => Promise<DoctorRating | null>;
   fetchDoctorRatings: (doctorId: number) => Promise<void>;
+  fetchMyRatings: () => Promise<void>;
   clearError: () => void;
   clearRatings: () => void;
   clearCurrentRating: () => void;
+  clearMyRatings: () => void;
 }
 
 export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
   doctorRatings: [],
   selectedDoctorId: null,
   currentRating: null,
+  myRatingsSummary: null,
+  myRatings: [],
   isLoading: false,
   error: null,
 
@@ -76,7 +83,24 @@ export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
     }
   },
 
+  fetchMyRatings: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await doctorRatingService.getMyRatings();
+      set({
+        myRatingsSummary: response.summary,
+        myRatings: response.ratings,
+        isLoading: false,
+        error: null,
+      });
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false });
+      throw error;
+    }
+  },
+
   clearError: () => set({ error: null }),
   clearRatings: () => set({ doctorRatings: [], selectedDoctorId: null }),
   clearCurrentRating: () => set({ currentRating: null }),
+  clearMyRatings: () => set({ myRatings: [], myRatingsSummary: null }),
 }));

--- a/mobile/types/doctorRating.ts
+++ b/mobile/types/doctorRating.ts
@@ -26,3 +26,14 @@ export const RATING_LABELS: Record<number, string> = {
   4: 'Bom',
   5: 'Excelente',
 };
+
+export interface RatingSummary {
+  total_ratings: number;
+  average_rating: number;
+  rating_distribution: Record<number, number>;
+}
+
+export interface MyRatingsResponse {
+  summary: RatingSummary;
+  ratings: DoctorRating[];
+}

--- a/web/app/Http/Controllers/Api/V1/DoctorRating/MyRatingsController.php
+++ b/web/app/Http/Controllers/Api/V1/DoctorRating/MyRatingsController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\DoctorRating;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\DoctorRatingResource;
+use App\Models\DoctorRating;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MyRatingsController extends Controller
+{
+    /**
+     * Get the authenticated doctor's ratings with summary statistics.
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($user->role !== 'doctor' || ! $user->doctor) {
+            return response()->json([
+                'message' => 'Apenas médicos podem acessar suas avaliações.',
+            ], 403);
+        }
+
+        $doctorId = $user->doctor->id;
+
+        $ratings = DoctorRating::where('doctor_id', $doctorId)
+            ->with(['receptor', 'medicationAppointment.medicationRequest.medicationOffering.drug'])
+            ->orderByDesc('created_at')
+            ->get();
+
+        $totalRatings  = $ratings->count();
+        $averageRating = $totalRatings > 0
+            ? round($ratings->avg('rating'), 1)
+            : 0;
+
+        $ratingDistribution = [
+            5 => $ratings->where('rating', 5)->count(),
+            4 => $ratings->where('rating', 4)->count(),
+            3 => $ratings->where('rating', 3)->count(),
+            2 => $ratings->where('rating', 2)->count(),
+            1 => $ratings->where('rating', 1)->count(),
+        ];
+
+        return response()->json([
+            'summary' => [
+                'total_ratings'       => $totalRatings,
+                'average_rating'      => $averageRating,
+                'rating_distribution' => $ratingDistribution,
+            ],
+            'ratings' => DoctorRatingResource::collection($ratings),
+        ]);
+    }
+}

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -120,6 +120,8 @@ Route::prefix('v1')->group(function (): void {
     });
 
     Route::prefix('doctor-ratings')->middleware('auth:sanctum')->group(function (): void {
+        Route::get('/my-ratings', DoctorRating\MyRatingsController::class)
+            ->name('api.v1.doctor-ratings.my-ratings');
         Route::post('/{medicationAppointment}', DoctorRating\StoreController::class)
             ->name('api.v1.doctor-ratings.store');
         Route::get('/appointment/{medicationAppointment}', DoctorRating\ShowByAppointmentController::class)

--- a/web/tests/Feature/Api/V1/DoctorRating/MyRatingsTest.php
+++ b/web/tests/Feature/Api/V1/DoctorRating/MyRatingsTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\Address;
+use App\Models\Doctor;
+use App\Models\DoctorRating;
+use App\Models\MedicationAppointment;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+// Helper function to create a complete rating flow
+function createRatingForDoctor(Doctor $doctor, User $receptor, int $rating = 5): DoctorRating
+{
+    $address     = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering    = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $request     = MedicationRequest::factory()->forReceptor($receptor)->forOffering($offering)->confirmed()->create();
+    $appointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request->id,
+        'address_id'            => $address->id,
+    ]);
+
+    return DoctorRating::factory()->create([
+        'medication_appointment_id' => $appointment->id,
+        'doctor_id'                 => $doctor->id,
+        'receptor_id'               => $receptor->id,
+        'rating'                    => $rating,
+    ]);
+}
+
+// Happy Path Tests
+
+it('should return ratings for authenticated doctor', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    createRatingForDoctor($doctor, $receptor, 5);
+    createRatingForDoctor($doctor, $receptor, 4);
+    createRatingForDoctor($doctor, $receptor, 5);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'summary' => [
+                'total_ratings',
+                'average_rating',
+                'rating_distribution' => [5, 4, 3, 2, 1],
+            ],
+            'ratings' => [
+                '*' => [
+                    'id',
+                    'rating',
+                    'comment',
+                    'created_at',
+                    'updated_at',
+                    'receptor',
+                ],
+            ],
+        ]);
+});
+
+it('should calculate correct summary statistics', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    // Create ratings with different values
+    createRatingForDoctor($doctor, $receptor, 5);
+    createRatingForDoctor($doctor, $receptor, 5);
+    createRatingForDoctor($doctor, $receptor, 4);
+    createRatingForDoctor($doctor, $receptor, 3);
+    createRatingForDoctor($doctor, $receptor, 2);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('summary.total_ratings', 5)
+        ->assertJsonPath('summary.average_rating', 3.8) // (5+5+4+3+2)/5 = 3.8
+        ->assertJsonPath('summary.rating_distribution.5', 2)
+        ->assertJsonPath('summary.rating_distribution.4', 1)
+        ->assertJsonPath('summary.rating_distribution.3', 1)
+        ->assertJsonPath('summary.rating_distribution.2', 1)
+        ->assertJsonPath('summary.rating_distribution.1', 0);
+});
+
+it('should return empty ratings for doctor with no ratings', function (): void {
+    $doctor = Doctor::factory()->create();
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('summary.total_ratings', 0)
+        ->assertJsonPath('summary.average_rating', 0)
+        ->assertJsonCount(0, 'ratings');
+});
+
+it('should return ratings ordered by most recent first', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    // Create old rating
+    $oldAddress     = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $oldOffering    = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $oldRequest     = MedicationRequest::factory()->forReceptor($receptor)->forOffering($oldOffering)->confirmed()->create();
+    $oldAppointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $oldRequest->id,
+        'address_id'            => $oldAddress->id,
+    ]);
+    DoctorRating::factory()->create([
+        'medication_appointment_id' => $oldAppointment->id,
+        'doctor_id'                 => $doctor->id,
+        'receptor_id'               => $receptor->id,
+        'rating'                    => 3,
+        'created_at'                => now()->subDays(5),
+    ]);
+
+    // Create new rating
+    $newAddress     = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $newOffering    = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $newRequest     = MedicationRequest::factory()->forReceptor($receptor)->forOffering($newOffering)->confirmed()->create();
+    $newAppointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $newRequest->id,
+        'address_id'            => $newAddress->id,
+    ]);
+    DoctorRating::factory()->create([
+        'medication_appointment_id' => $newAppointment->id,
+        'doctor_id'                 => $doctor->id,
+        'receptor_id'               => $receptor->id,
+        'rating'                    => 5,
+        'created_at'                => now(),
+    ]);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('ratings.0.rating', 5)
+        ->assertJsonPath('ratings.1.rating', 3);
+});
+
+it('should include receptor information', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create(['name' => 'Maria Santos']);
+
+    createRatingForDoctor($doctor, $receptor, 5);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('ratings.0.receptor.name', 'Maria Santos');
+});
+
+it('should include medication appointment information', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    createRatingForDoctor($doctor, $receptor, 5);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'ratings' => [
+                '*' => [
+                    'medication_appointment',
+                ],
+            ],
+        ]);
+});
+
+// Authorization Error Tests
+
+it('should return 401 for unauthenticated users', function (): void {
+    getJson('/api/v1/doctor-ratings/my-ratings')
+        ->assertUnauthorized();
+});
+
+it('should return 403 for receptor users', function (): void {
+    $receptor = User::factory()->receptor()->create();
+
+    actingAs($receptor);
+
+    getJson('/api/v1/doctor-ratings/my-ratings')
+        ->assertForbidden()
+        ->assertJsonPath('message', 'Apenas médicos podem acessar suas avaliações.');
+});
+
+it('should only return ratings for the authenticated doctor', function (): void {
+    $doctor1  = Doctor::factory()->create();
+    $doctor2  = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    // Create rating for doctor1
+    createRatingForDoctor($doctor1, $receptor, 5);
+    createRatingForDoctor($doctor1, $receptor, 4);
+
+    // Create rating for doctor2
+    createRatingForDoctor($doctor2, $receptor, 3);
+
+    actingAs($doctor1->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('summary.total_ratings', 2)
+        ->assertJsonCount(2, 'ratings');
+});
+
+// Edge Cases
+
+it('should handle ratings with null comments', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    $address     = Address::factory()->create(['user_id' => $doctor->user->id]);
+    $offering    = MedicationOffering::factory()->completed()->create(['doctor_id' => $doctor->id]);
+    $request     = MedicationRequest::factory()->forReceptor($receptor)->forOffering($offering)->confirmed()->create();
+    $appointment = MedicationAppointment::factory()->completed()->create([
+        'medication_request_id' => $request->id,
+        'address_id'            => $address->id,
+    ]);
+
+    DoctorRating::factory()->withoutComment()->create([
+        'medication_appointment_id' => $appointment->id,
+        'doctor_id'                 => $doctor->id,
+        'receptor_id'               => $receptor->id,
+        'rating'                    => 5,
+    ]);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('ratings.0.comment', null);
+});
+
+it('should correctly round average to one decimal place', function (): void {
+    $doctor   = Doctor::factory()->create();
+    $receptor = User::factory()->receptor()->create();
+
+    // Create ratings that result in a number that needs rounding
+    // 4, 4, 3 = 11/3 = 3.666... should round to 3.7
+    createRatingForDoctor($doctor, $receptor, 4);
+    createRatingForDoctor($doctor, $receptor, 4);
+    createRatingForDoctor($doctor, $receptor, 3);
+
+    actingAs($doctor->user);
+
+    $response = getJson('/api/v1/doctor-ratings/my-ratings');
+
+    $response->assertOk()
+        ->assertJsonPath('summary.average_rating', 3.7);
+});


### PR DESCRIPTION
## Summary
- Add endpoint `GET /api/v1/doctor-ratings/my-ratings` for doctors to view their own ratings
- Create mobile screen for doctors to visualize their feedback with summary statistics
- Include rating distribution chart, average rating, and detailed feedback list
- Add navigation button "Minhas Avaliações" in doctor dashboard

## Changes

### Backend (API)
- **New Controller:** `MyRatingsController` - Returns ratings with summary (average, total, distribution)
- **New Route:** `GET /api/v1/doctor-ratings/my-ratings` (auth required, doctors only)
- **Tests:** 11 feature tests covering auth, authorization, and response format

### Mobile (React Native/Expo)
- **New Screen:** `doctor/ratings.tsx` - Displays ratings summary and list
- **Service:** Added `getMyRatings()` to `doctorRatingService`
- **Store:** Added `fetchMyRatings`, `myRatings`, `myRatingsSummary` to store
- **Types:** Added `RatingSummary` and `MyRatingsResponse` interfaces
- **Dashboard:** Added "Minhas Avaliações" button for doctors

## Test plan
- [x] Backend: 11 tests passing
- [x] Lint: PHPStan level 6 + ESLint passing
- [ ] Manual test: Doctor can see ratings summary and list

Closes #63