### PR TITLE
feat(web): implement activity monitoring system for admin panel

### DIFF
--- a/docs/ACTIVITY_LOGGING.md
+++ b/docs/ACTIVITY_LOGGING.md
@@ -1,0 +1,334 @@
+# Activity Logging - Arquitetura e Funcionamento
+
+## Visão Geral
+
+O sistema de activity logging do DoaFarma permite rastrear todas as atividades importantes na plataforma, incluindo criação, atualização e exclusão de entidades, além de ações customizadas como aprovação/rejeição de usuários.
+
+O objetivo é:
+- **Auditoria:** Saber quem fez o que e quando
+- **Monitoramento:** Detectar comportamentos suspeitos ou mau uso
+- **Debugging:** Entender o histórico de mudanças em uma entidade
+- **Compliance:** Manter registro de todas as ações para conformidade
+
+## Arquitetura
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           FLUXO DE ACTIVITY LOGGING                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────┐      ┌──────────────────┐      ┌──────────────────┐
+│     Model        │      │  LogsActivity    │      │  Activity Log    │
+│  (User, Offer,   │      │    Trait         │      │    Table         │
+│   Request, etc)  │      │                  │      │  (PostgreSQL)    │
+└────────┬─────────┘      └────────┬─────────┘      └────────┬─────────┘
+         │                         │                         │
+         │ 1. create()/update()    │                         │
+         │    /delete()            │                         │
+         ├────────────────────────>│                         │
+         │                         │                         │
+         │                         │ 2. Intercepta evento    │
+         │                         │    via model events     │
+         │                         │                         │
+         │                         │ 3. Captura:             │
+         │                         │    - subject (model)    │
+         │                         │    - causer (auth user) │
+         │                         │    - old/new values     │
+         │                         │    - event type         │
+         │                         │                         │
+         │                         │ 4. INSERT activity_log  │
+         │                         ├────────────────────────>│
+         │                         │                         │
+         │                         │                         │
+┌────────┴─────────┐      ┌────────┴─────────┐      ┌────────┴─────────┐
+│    Filament      │      │ ActivityLog      │      │   Dashboard      │
+│    Admin         │<─────│   Resource       │<─────│    Widgets       │
+│    Panel         │      │                  │      │                  │
+└──────────────────┘      └──────────────────┘      └──────────────────┘
+```
+
+## Componentes
+
+### Backend (Laravel)
+
+| Componente | Caminho | Responsabilidade |
+|------------|---------|------------------|
+| **Spatie Activity Log** | Package via Composer | Biblioteca que gerencia o logging automático |
+| **Config** | `config/activitylog.php` | Configurações do pacote (conexão, tabela, etc) |
+| **User** | `app/Models/User.php` | Model com `LogsActivity` trait |
+| **MedicationOffering** | `app/Models/MedicationOffering.php` | Model com `LogsActivity` trait |
+| **MedicationRequest** | `app/Models/MedicationRequest.php` | Model com `LogsActivity` trait |
+| **MedicationAppointment** | `app/Models/MedicationAppointment.php` | Model com `LogsActivity` trait |
+| **ActivityLogResource** | `app/Filament/Resources/ActivityLogResource.php` | Resource Filament para visualizar logs |
+| **ActivityStatsWidget** | `app/Filament/Widgets/ActivityStatsWidget.php` | Stats no dashboard (hoje/semana/mês) |
+| **RecentActivityWidget** | `app/Filament/Widgets/RecentActivityWidget.php` | Últimas 10 atividades no dashboard |
+
+### Tabela de Banco de Dados
+
+```sql
+CREATE TABLE activity_log (
+    id BIGINT PRIMARY KEY,
+    log_name VARCHAR(255),
+    description TEXT NOT NULL,
+    subject_type VARCHAR(255),        -- Ex: App\Models\User
+    subject_id BIGINT,                -- ID do modelo afetado
+    causer_type VARCHAR(255),         -- Ex: App\Models\User
+    causer_id BIGINT,                 -- ID de quem fez a ação
+    properties JSON,                  -- old/new values em JSON
+    event VARCHAR(255),               -- created, updated, deleted, approved, rejected
+    batch_uuid UUID,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+
+    INDEX idx_log_name (log_name),
+    INDEX idx_subject (subject_type, subject_id),
+    INDEX idx_causer (causer_type, causer_id)
+);
+```
+
+## Fluxo Detalhado
+
+### 1. Logging Automático (via Trait)
+
+Ao adicionar a trait `LogsActivity` a um model, todas as operações CRUD são automaticamente logadas:
+
+```php
+// app/Models/User.php
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class User extends Authenticatable
+{
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'email', 'phone_number', 'cpf', 'role', 'status'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+                'created' => "Usuário {$this->name} foi criado",
+                'updated' => "Usuário {$this->name} foi atualizado",
+                'deleted' => "Usuário {$this->name} foi removido",
+                default   => "Usuário {$this->name}: {$eventName}",
+            });
+    }
+}
+```
+
+### 2. Logging Manual (Ações Customizadas)
+
+Para eventos que não são operações CRUD padrão, use o helper `activity()`:
+
+```php
+// Exemplo: aprovar um usuário
+use Illuminate\Support\Facades\Auth;
+
+$oldStatus = $user->status;
+$user->update(['status' => UserStatus::Approved]);
+
+activity()
+    ->performedOn($user)                    // Model afetado
+    ->causedBy(Auth::user())                // Quem fez
+    ->withProperties([
+        'old' => ['status' => $oldStatus->value],
+        'attributes' => ['status' => UserStatus::Approved->value],
+    ])
+    ->event('approved')                     // Evento customizado
+    ->log("Usuário {$user->name} foi aprovado");
+```
+
+### 3. Visualização no Admin
+
+O `ActivityLogResource` permite:
+- Listar todas as atividades com filtros
+- Filtrar por tipo de entidade (Usuário, Oferta, Solicitação, etc)
+- Filtrar por tipo de ação (criado, atualizado, removido, aprovado, rejeitado)
+- Filtrar por período
+- Ver detalhes: valores antigos e novos em formato JSON
+
+## Tipos de Eventos
+
+### Eventos Automáticos (CRUD)
+
+| Evento | Descrição | Quando Ocorre |
+|--------|-----------|---------------|
+| `created` | Registro criado | `Model::create()` ou `$model->save()` (novo) |
+| `updated` | Registro atualizado | `$model->update()` ou `$model->save()` (existente) |
+| `deleted` | Registro removido | `$model->delete()` |
+
+### Eventos Customizados
+
+| Evento | Descrição | Onde é Registrado |
+|--------|-----------|-------------------|
+| `approved` | Usuário aprovado | `UserResource.php` (ação de aprovação) |
+| `rejected` | Usuário rejeitado | `UserResource.php` (ação de rejeição) |
+
+## Como Adicionar a Novos Models
+
+### Passo 1: Adicionar a Trait
+
+```php
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class NovoModel extends Model
+{
+    use LogsActivity;
+}
+```
+
+### Passo 2: Configurar Opções
+
+```php
+public function getActivitylogOptions(): LogOptions
+{
+    return LogOptions::defaults()
+        // Campos que devem ser logados (exclua senhas, tokens, etc)
+        ->logOnly(['campo1', 'campo2', 'status'])
+        // Só loga se algo realmente mudou
+        ->logOnlyDirty()
+        // Não cria log vazio se nada mudou
+        ->dontSubmitEmptyLogs()
+        // Descrição amigável em português
+        ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+            'created' => "Registro {$this->id} foi criado",
+            'updated' => "Registro {$this->id} foi atualizado",
+            'deleted' => "Registro {$this->id} foi removido",
+            default   => "Registro {$this->id}: {$eventName}",
+        });
+}
+```
+
+### Passo 3: Atualizar RecentActivityWidget
+
+Adicione o novo model ao mapeamento de labels em `RecentActivityWidget.php`:
+
+```php
+Tables\Columns\TextColumn::make('subject_type')
+    ->formatStateUsing(fn (?string $state): string => match ($state) {
+        \App\Models\User::class                  => 'Usuário',
+        \App\Models\MedicationOffering::class    => 'Oferta',
+        \App\Models\MedicationRequest::class     => 'Solicitação',
+        \App\Models\MedicationAppointment::class => 'Agendamento',
+        \App\Models\NovoModel::class             => 'Novo Model',  // <- Adicione aqui
+        default                                  => 'Outro',
+    })
+```
+
+### Passo 4: Criar Testes
+
+```php
+// tests/Feature/ActivityLogTest.php
+describe('NovoModel Activity Logging', function (): void {
+    it('logs when a novo model is created', function (): void {
+        $model = NovoModel::factory()->create();
+
+        $activity = Activity::where('subject_type', NovoModel::class)
+            ->where('subject_id', $model->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->description)->toContain('criado');
+    });
+});
+```
+
+## Configuração
+
+### activitylog.php
+
+```php
+return [
+    'enabled' => env('ACTIVITY_LOGGER_ENABLED', true),
+    'delete_records_older_than_days' => 365, // Limpar logs antigos
+    'default_log_name' => 'default',
+    'default_auth_driver' => null,
+    'subject_returns_soft_deleted_models' => false,
+    'activity_model' => \Spatie\Activitylog\Models\Activity::class,
+    'table_name' => 'activity_log',
+    'database_connection' => env('ACTIVITY_LOGGER_DB_CONNECTION'),
+];
+```
+
+## Boas Práticas
+
+### DO (Faça)
+
+- **Sempre** adicione `LogsActivity` a models de domínio importantes
+- **Sempre** defina `logOnly()` para evitar logar dados sensíveis
+- **Use** `logOnlyDirty()` para evitar logs desnecessários
+- **Crie** eventos customizados para ações de negócio importantes
+- **Escreva** descrições em português e amigáveis
+- **Teste** que os logs são criados corretamente
+
+### DON'T (Não Faça)
+
+- **Não** logue campos sensíveis (senha, tokens, chaves API)
+- **Não** crie logs para operações triviais ou internas
+- **Não** esqueça de atualizar widgets ao adicionar novos models
+- **Não** dependa apenas dos logs para auditoria crítica (considere também database triggers)
+
+## Consultas Úteis
+
+### Últimas atividades de um usuário específico
+
+```php
+Activity::causedBy($user)
+    ->latest()
+    ->take(10)
+    ->get();
+```
+
+### Histórico de um model específico
+
+```php
+Activity::where('subject_type', User::class)
+    ->where('subject_id', $userId)
+    ->latest()
+    ->get();
+```
+
+### Atividades de aprovação no último mês
+
+```php
+Activity::where('event', 'approved')
+    ->where('created_at', '>=', now()->subMonth())
+    ->get();
+```
+
+### Atividades por tipo de entidade
+
+```php
+Activity::where('subject_type', MedicationOffering::class)
+    ->whereBetween('created_at', [$startDate, $endDate])
+    ->get();
+```
+
+## Testes
+
+### Rodar testes de Activity Log
+
+```bash
+php artisan test --filter=ActivityLogTest
+```
+
+### Testes cobertos
+
+- Logging de criação de usuário
+- Logging de atualização de usuário
+- Não logar quando campos não mudam
+- Logging de criação de MedicationOffering
+- Logging de mudança de status de MedicationOffering
+- Logging de criação de MedicationRequest
+- Logging de mudança de status de MedicationRequest
+- Tracking do causer (quem fez a mudança)
+
+## Segurança
+
+- Campos sensíveis (senha, remember_token) são excluídos do logging
+- Activity logs são somente leitura no admin (sem edição/deleção)
+- Acesso ao ActivityLogResource requer autenticação admin
+- Logs são armazenados no banco principal com índices para performance

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -139,3 +139,66 @@ refactor(web): extract validation to form request
 - feature branches: created per task and merged into develop
 
 All changes are tested locally before merging.
+
+## Activity Logging
+
+### Regra Obrigatória
+
+**Todos os models de domínio importantes DEVEM ter activity logging.**
+
+Isso inclui qualquer model que represente uma entidade de negócio que os administradores precisem auditar.
+
+### Como Adicionar
+
+1. **Adicione a trait `LogsActivity` ao model:**
+
+```php
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class NovoModel extends Model
+{
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['campo1', 'campo2', 'status'])  // Campos a logar
+            ->logOnlyDirty()                           // Só loga mudanças reais
+            ->dontSubmitEmptyLogs()                    // Não cria log vazio
+            ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+                'created' => "Registro foi criado",
+                'updated' => "Registro foi atualizado",
+                'deleted' => "Registro foi removido",
+                default   => "Registro: {$eventName}",
+            });
+    }
+}
+```
+
+2. **Atualize o widget de atividades recentes:**
+
+Em `app/Filament/Widgets/RecentActivityWidget.php`, adicione o novo model ao mapeamento de labels.
+
+3. **Crie testes para verificar o logging:**
+
+```php
+it('logs when novo model is created', function (): void {
+    $model = NovoModel::factory()->create();
+    $activity = Activity::where('subject_type', NovoModel::class)
+        ->where('subject_id', $model->id)
+        ->where('event', 'created')
+        ->first();
+    expect($activity)->not->toBeNull();
+});
+```
+
+### O que NÃO Logar
+
+- Campos sensíveis (senhas, tokens, chaves API)
+- Models auxiliares ou de infraestrutura
+- Operações em batch de alto volume
+
+### Documentação Completa
+
+Veja `docs/ACTIVITY_LOGGING.md` para detalhes sobre arquitetura, consultas úteis e boas práticas.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -190,6 +190,33 @@ Addresses are stored as text. Geocoding, map integration, or proximity search ar
 
 ---
 
+### D13: Spatie Activity Log for Platform Monitoring
+
+**Decision:** Use spatie/laravel-activitylog package for tracking all system activities.
+
+**Rationale:**
+- Battle-tested, widely used in Laravel community
+- Automatic tracking via model traits
+- Tracks before/after values for updates
+- Identifies who made each change (causer)
+- Minimal configuration needed
+- Integrates seamlessly with Filament admin panel
+
+**Implementation:**
+- Models with `LogsActivity` trait: User, MedicationOffering, MedicationRequest, MedicationAppointment
+- Custom events for user approval/rejection actions
+- ActivityLogResource in Filament for admin viewing
+- Dashboard widgets for activity statistics and recent actions
+- Filters by entity type, action, date range, and user
+
+**Benefits:**
+- Admin can monitor all platform activity
+- Audit trail for security and compliance
+- Helps identify misuse or suspicious patterns
+- Historical record of all changes
+
+---
+
 ## Future Considerations
 
 Items explicitly out of scope but documented for awareness:

--- a/web/app/Filament/Resources/ActivityLogResource.php
+++ b/web/app/Filament/Resources/ActivityLogResource.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ActivityLogResource\Pages;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityLogResource extends Resource
+{
+    protected static ?string $model = Activity::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static ?string $modelLabel = 'Registro de Atividade';
+
+    protected static ?string $pluralModelLabel = 'Registros de Atividades';
+
+    protected static ?string $navigationGroup = 'Monitoramento';
+
+    protected static ?int $navigationSort = 1;
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Data/Hora')
+                    ->dateTime('d/m/Y H:i:s')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('causer.name')
+                    ->label('Usuário')
+                    ->placeholder('Sistema')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('event')
+                    ->label('Ação')
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state): string => match ($state) {
+                        'created'  => 'Criado',
+                        'updated'  => 'Atualizado',
+                        'deleted'  => 'Removido',
+                        'approved' => 'Aprovado',
+                        'rejected' => 'Rejeitado',
+                        default    => $state ?? 'Desconhecido',
+                    })
+                    ->color(fn (?string $state): string => match ($state) {
+                        'created'  => 'success',
+                        'updated'  => 'info',
+                        'deleted'  => 'danger',
+                        'approved' => 'success',
+                        'rejected' => 'danger',
+                        default    => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('subject_type')
+                    ->label('Entidade')
+                    ->formatStateUsing(fn (?string $state): string => match ($state) {
+                        \App\Models\User::class                  => 'Usuário',
+                        \App\Models\MedicationOffering::class    => 'Oferta de Medicamento',
+                        \App\Models\MedicationRequest::class     => 'Solicitação',
+                        \App\Models\MedicationAppointment::class => 'Agendamento',
+                        \App\Models\Doctor::class                => 'Médico',
+                        \App\Models\DoctorRating::class          => 'Avaliação',
+                        default                                  => $state ?? 'N/A',
+                    })
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('subject_id')
+                    ->label('ID')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('description')
+                    ->label('Descrição')
+                    ->limit(50)
+                    ->tooltip(fn (Activity $record): string => $record->description ?? ''),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('event')
+                    ->label('Ação')
+                    ->options([
+                        'created'  => 'Criado',
+                        'updated'  => 'Atualizado',
+                        'deleted'  => 'Removido',
+                        'approved' => 'Aprovado',
+                        'rejected' => 'Rejeitado',
+                    ]),
+                Tables\Filters\SelectFilter::make('subject_type')
+                    ->label('Entidade')
+                    ->options([
+                        \App\Models\User::class                  => 'Usuário',
+                        \App\Models\MedicationOffering::class    => 'Oferta de Medicamento',
+                        \App\Models\MedicationRequest::class     => 'Solicitação',
+                        \App\Models\MedicationAppointment::class => 'Agendamento',
+                    ]),
+                Tables\Filters\Filter::make('created_at')
+                    ->form([
+                        \Filament\Forms\Components\DatePicker::make('from')
+                            ->label('De'),
+                        \Filament\Forms\Components\DatePicker::make('until')
+                            ->label('Até'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when(
+                            $data['from'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('created_at', '>=', $date),
+                        )
+                        ->when(
+                            $data['until'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('created_at', '<=', $date),
+                        )),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    #[\Override]
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Informações do Registro')
+                    ->schema([
+                        TextEntry::make('created_at')
+                            ->label('Data/Hora')
+                            ->dateTime('d/m/Y H:i:s'),
+                        TextEntry::make('causer.name')
+                            ->label('Realizado por')
+                            ->placeholder('Sistema'),
+                        TextEntry::make('event')
+                            ->label('Ação')
+                            ->badge()
+                            ->formatStateUsing(fn (?string $state): string => match ($state) {
+                                'created'  => 'Criado',
+                                'updated'  => 'Atualizado',
+                                'deleted'  => 'Removido',
+                                'approved' => 'Aprovado',
+                                'rejected' => 'Rejeitado',
+                                default    => $state ?? 'Desconhecido',
+                            })
+                            ->color(fn (?string $state): string => match ($state) {
+                                'created'  => 'success',
+                                'updated'  => 'info',
+                                'deleted'  => 'danger',
+                                'approved' => 'success',
+                                'rejected' => 'danger',
+                                default    => 'gray',
+                            }),
+                        TextEntry::make('subject_type')
+                            ->label('Tipo de Entidade')
+                            ->formatStateUsing(fn (?string $state): string => match ($state) {
+                                \App\Models\User::class                  => 'Usuário',
+                                \App\Models\MedicationOffering::class    => 'Oferta de Medicamento',
+                                \App\Models\MedicationRequest::class     => 'Solicitação',
+                                \App\Models\MedicationAppointment::class => 'Agendamento',
+                                \App\Models\Doctor::class                => 'Médico',
+                                \App\Models\DoctorRating::class          => 'Avaliação',
+                                default                                  => $state ?? 'N/A',
+                            }),
+                        TextEntry::make('subject_id')
+                            ->label('ID da Entidade'),
+                        TextEntry::make('description')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2),
+                Section::make('Alterações')
+                    ->schema([
+                        TextEntry::make('properties.old')
+                            ->label('Valores Anteriores')
+                            ->formatStateUsing(fn ($state) => $state ? json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) : 'N/A')
+                            ->markdown()
+                            ->columnSpanFull(),
+                        TextEntry::make('properties.attributes')
+                            ->label('Novos Valores')
+                            ->formatStateUsing(fn ($state) => $state ? json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) : 'N/A')
+                            ->markdown()
+                            ->columnSpanFull(),
+                    ])
+                    ->collapsible(),
+            ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListActivityLogs::route('/'),
+            'view'  => Pages\ViewActivityLog::route('/{record}'),
+        ];
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+}

--- a/web/app/Filament/Resources/ActivityLogResource/Pages/ListActivityLogs.php
+++ b/web/app/Filament/Resources/ActivityLogResource/Pages/ListActivityLogs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\ActivityLogResource\Pages;
+
+use App\Filament\Resources\ActivityLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListActivityLogs extends ListRecords
+{
+    protected static string $resource = ActivityLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/web/app/Filament/Resources/ActivityLogResource/Pages/ViewActivityLog.php
+++ b/web/app/Filament/Resources/ActivityLogResource/Pages/ViewActivityLog.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\ActivityLogResource\Pages;
+
+use App\Filament\Resources\ActivityLogResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewActivityLog extends ViewRecord
+{
+    protected static string $resource = ActivityLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/web/app/Filament/Resources/UserResource.php
+++ b/web/app/Filament/Resources/UserResource.php
@@ -29,6 +29,7 @@ class UserResource extends Resource
 
     protected static ?string $navigationGroup = 'Gerenciamento';
 
+    #[\Override]
     public static function form(Form $form): Form
     {
         return $form
@@ -95,6 +96,7 @@ class UserResource extends Resource
             ]);
     }
 
+    #[\Override]
     public static function table(Table $table): Table
     {
         return $table
@@ -161,11 +163,23 @@ class UserResource extends Resource
                     ->modalSubmitActionLabel('Sim, aprovar')
                     ->visible(fn (User $record): bool => $record->status === UserStatus::Pending)
                     ->action(function (User $record): void {
+                        $oldStatus = $record->status;
+
                         $record->update([
                             'status'            => UserStatus::Approved,
                             'status_changed_at' => now(),
                             'status_changed_by' => Auth::id(),
                         ]);
+
+                        activity()
+                            ->performedOn($record)
+                            ->causedBy(Auth::user())
+                            ->withProperties([
+                                'old'        => ['status' => $oldStatus->value],
+                                'attributes' => ['status' => UserStatus::Approved->value],
+                            ])
+                            ->event('approved')
+                            ->log("Usuário {$record->name} foi aprovado");
 
                         Notification::make()
                             ->title('Usuário aprovado com sucesso!')
@@ -182,11 +196,23 @@ class UserResource extends Resource
                     ->modalSubmitActionLabel('Sim, rejeitar')
                     ->visible(fn (User $record): bool => $record->status === UserStatus::Pending)
                     ->action(function (User $record): void {
+                        $oldStatus = $record->status;
+
                         $record->update([
                             'status'            => UserStatus::Rejected,
                             'status_changed_at' => now(),
                             'status_changed_by' => Auth::id(),
                         ]);
+
+                        activity()
+                            ->performedOn($record)
+                            ->causedBy(Auth::user())
+                            ->withProperties([
+                                'old'        => ['status' => $oldStatus->value],
+                                'attributes' => ['status' => UserStatus::Rejected->value],
+                            ])
+                            ->event('rejected')
+                            ->log("Usuário {$record->name} foi rejeitado");
 
                         Notification::make()
                             ->title('Usuário rejeitado.')
@@ -204,18 +230,32 @@ class UserResource extends Resource
                         ->color('success')
                         ->requiresConfirmation()
                         ->action(function ($records): void {
-                            $records->each(function (User $record): void {
+                            $count = 0;
+                            $records->each(function (User $record) use (&$count): void {
                                 if ($record->status === UserStatus::Pending) {
+                                    $oldStatus = $record->status;
                                     $record->update([
                                         'status'            => UserStatus::Approved,
                                         'status_changed_at' => now(),
                                         'status_changed_by' => Auth::id(),
                                     ]);
+
+                                    activity()
+                                        ->performedOn($record)
+                                        ->causedBy(Auth::user())
+                                        ->withProperties([
+                                            'old'        => ['status' => $oldStatus->value],
+                                            'attributes' => ['status' => UserStatus::Approved->value],
+                                        ])
+                                        ->event('approved')
+                                        ->log("Usuário {$record->name} foi aprovado (em lote)");
+
+                                    $count++;
                                 }
                             });
 
                             Notification::make()
-                                ->title('Usuários aprovados com sucesso!')
+                                ->title("$count usuário(s) aprovado(s) com sucesso!")
                                 ->success()
                                 ->send();
                         }),
@@ -225,18 +265,32 @@ class UserResource extends Resource
                         ->color('danger')
                         ->requiresConfirmation()
                         ->action(function ($records): void {
-                            $records->each(function (User $record): void {
+                            $count = 0;
+                            $records->each(function (User $record) use (&$count): void {
                                 if ($record->status === UserStatus::Pending) {
+                                    $oldStatus = $record->status;
                                     $record->update([
                                         'status'            => UserStatus::Rejected,
                                         'status_changed_at' => now(),
                                         'status_changed_by' => Auth::id(),
                                     ]);
+
+                                    activity()
+                                        ->performedOn($record)
+                                        ->causedBy(Auth::user())
+                                        ->withProperties([
+                                            'old'        => ['status' => $oldStatus->value],
+                                            'attributes' => ['status' => UserStatus::Rejected->value],
+                                        ])
+                                        ->event('rejected')
+                                        ->log("Usuário {$record->name} foi rejeitado (em lote)");
+
+                                    $count++;
                                 }
                             });
 
                             Notification::make()
-                                ->title('Usuários rejeitados.')
+                                ->title("$count usuário(s) rejeitado(s).")
                                 ->warning()
                                 ->send();
                         }),
@@ -244,6 +298,7 @@ class UserResource extends Resource
             ]);
     }
 
+    #[\Override]
     public static function getRelations(): array
     {
         return [
@@ -251,6 +306,7 @@ class UserResource extends Resource
         ];
     }
 
+    #[\Override]
     public static function getPages(): array
     {
         return [
@@ -276,6 +332,7 @@ class UserResource extends Resource
     /**
      * @return Builder<User>
      */
+    #[\Override]
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()

--- a/web/app/Filament/Resources/UserResource.php
+++ b/web/app/Filament/Resources/UserResource.php
@@ -53,6 +53,16 @@ class UserResource extends Resource
                         Forms\Components\TextInput::make('cpf')
                             ->label('CPF')
                             ->maxLength(11),
+                        Forms\Components\TextInput::make('password')
+                            ->label('Senha')
+                            ->password()
+                            ->required(fn (string $operation): bool => $operation === 'create')
+                            ->dehydrated(fn (?string $state): bool => filled($state))
+                            ->dehydrateStateUsing(fn (string $state): string => bcrypt($state))
+                            ->maxLength(255)
+                            ->helperText(fn (string $operation): string => $operation === 'edit'
+                                ? 'Deixe em branco para manter a senha atual'
+                                : 'Mínimo de 8 caracteres'),
                     ])
                     ->columns(2),
 

--- a/web/app/Filament/Widgets/ActivityStatsWidget.php
+++ b/web/app/Filament/Widgets/ActivityStatsWidget.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityStatsWidget extends BaseWidget
+{
+    protected static ?int $sort = 3;
+
+    #[\Override]
+    protected function getStats(): array
+    {
+        $today     = now()->startOfDay();
+        $thisWeek  = now()->startOfWeek();
+        $thisMonth = now()->startOfMonth();
+
+        return [
+            Stat::make('Atividades Hoje', Activity::where('created_at', '>=', $today)->count())
+                ->description('Registros nas últimas 24h')
+                ->descriptionIcon('heroicon-m-clock')
+                ->color('info'),
+            Stat::make('Atividades na Semana', Activity::where('created_at', '>=', $thisWeek)->count())
+                ->description('Últimos 7 dias')
+                ->descriptionIcon('heroicon-m-calendar')
+                ->color('success'),
+            Stat::make('Atividades no Mês', Activity::where('created_at', '>=', $thisMonth)->count())
+                ->description('Mês atual')
+                ->descriptionIcon('heroicon-m-chart-bar')
+                ->color('warning'),
+        ];
+    }
+}

--- a/web/app/Filament/Widgets/RecentActivityWidget.php
+++ b/web/app/Filament/Widgets/RecentActivityWidget.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Widgets;
+
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Spatie\Activitylog\Models\Activity;
+
+class RecentActivityWidget extends BaseWidget
+{
+    protected static ?int $sort = 2;
+
+    protected int | string | array $columnSpan = 'full';
+
+    protected static ?string $heading = 'Atividades Recentes';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Activity::query()
+                    ->latest()
+                    ->limit(10)
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Data/Hora')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('causer.name')
+                    ->label('Usuário')
+                    ->placeholder('Sistema'),
+                Tables\Columns\TextColumn::make('event')
+                    ->label('Ação')
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state): string => match ($state) {
+                        'created'  => 'Criado',
+                        'updated'  => 'Atualizado',
+                        'deleted'  => 'Removido',
+                        'approved' => 'Aprovado',
+                        'rejected' => 'Rejeitado',
+                        default    => $state ?? 'Desconhecido',
+                    })
+                    ->color(fn (?string $state): string => match ($state) {
+                        'created'  => 'success',
+                        'updated'  => 'info',
+                        'deleted'  => 'danger',
+                        'approved' => 'success',
+                        'rejected' => 'danger',
+                        default    => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('subject_type')
+                    ->label('Entidade')
+                    ->formatStateUsing(fn (?string $state): string => match ($state) {
+                        \App\Models\User::class                  => 'Usuário',
+                        \App\Models\MedicationOffering::class    => 'Oferta',
+                        \App\Models\MedicationRequest::class     => 'Solicitação',
+                        \App\Models\MedicationAppointment::class => 'Agendamento',
+                        default                                  => 'Outro',
+                    })
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('description')
+                    ->label('Descrição')
+                    ->limit(40),
+            ])
+            ->paginated(false)
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/web/app/Filament/Widgets/UserStatsWidget.php
+++ b/web/app/Filament/Widgets/UserStatsWidget.php
@@ -12,6 +12,7 @@ use Filament\Widgets\StatsOverviewWidget\Stat;
 
 class UserStatsWidget extends BaseWidget
 {
+    #[\Override]
     protected function getStats(): array
     {
         return [

--- a/web/app/Models/MedicationAppointment.php
+++ b/web/app/Models/MedicationAppointment.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
  * @property Carbon $scheduled_date
@@ -19,6 +21,7 @@ class MedicationAppointment extends Model
 {
     /** @use HasFactory<\Database\Factories\MedicationAppointmentFactory> */
     use HasFactory;
+    use LogsActivity;
 
     protected $table = 'medication_appointments';
 
@@ -142,5 +145,22 @@ class MedicationAppointment extends Model
     {
         return $query->orderBy('scheduled_date')
             ->orderBy('scheduled_time');
+    }
+
+    /**
+     * Configure activity logging options.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['medication_request_id', 'address_id', 'scheduled_date', 'scheduled_time', 'status', 'receptor_confirmed', 'doctor_confirmed'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+                'created' => "Agendamento #{$this->id} criado",
+                'updated' => "Agendamento #{$this->id} atualizado",
+                'deleted' => "Agendamento #{$this->id} removido",
+                default   => "Agendamento #{$this->id}: {$eventName}",
+            });
     }
 }

--- a/web/app/Models/MedicationOffering.php
+++ b/web/app/Models/MedicationOffering.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
  * @property \Carbon\Carbon $expires_at
@@ -18,6 +20,7 @@ class MedicationOffering extends Model
 {
     /** @use HasFactory<\Database\Factories\MedicationOfferingFactory> */
     use HasFactory;
+    use LogsActivity;
 
     protected $table = 'medication_offerings';
 
@@ -112,5 +115,22 @@ class MedicationOffering extends Model
     public function scopeCompleted(Builder $query): Builder
     {
         return $query->where('status', 'completed');
+    }
+
+    /**
+     * Configure activity logging options.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['doctor_id', 'drug_id', 'lot_number', 'expires_at', 'quantity', 'status'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+                'created' => "Oferta de medicamento #{$this->id} criada",
+                'updated' => "Oferta de medicamento #{$this->id} atualizada",
+                'deleted' => "Oferta de medicamento #{$this->id} removida",
+                default   => "Oferta #{$this->id}: {$eventName}",
+            });
     }
 }

--- a/web/app/Models/MedicationRequest.php
+++ b/web/app/Models/MedicationRequest.php
@@ -9,11 +9,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class MedicationRequest extends Model
 {
     /** @use HasFactory<\Database\Factories\MedicationRequestFactory> */
     use HasFactory;
+    use LogsActivity;
 
     protected $table = 'medication_requests';
 
@@ -84,5 +87,22 @@ class MedicationRequest extends Model
     public function scopeRejected(Builder $query): Builder
     {
         return $query->where('status', 'rejected');
+    }
+
+    /**
+     * Configure activity logging options.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['receptor_id', 'medication_offering_id', 'status'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+                'created' => "Solicitação de medicamento #{$this->id} criada",
+                'updated' => "Solicitação de medicamento #{$this->id} atualizada",
+                'deleted' => "Solicitação de medicamento #{$this->id} removida",
+                default   => "Solicitação #{$this->id}: {$eventName}",
+            });
     }
 }

--- a/web/app/Models/User.php
+++ b/web/app/Models/User.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
  * @property UserRole $role
@@ -25,6 +27,7 @@ class User extends Authenticatable implements MustVerifyEmail
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory;
     use HasApiTokens;
+    use LogsActivity;
     use Notifiable;
 
     protected $fillable = [
@@ -161,5 +164,22 @@ class User extends Authenticatable implements MustVerifyEmail
     public function statusChangedByAdmin(): BelongsTo
     {
         return $this->belongsTo(User::class, 'status_changed_by');
+    }
+
+    /**
+     * Configure activity logging options.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'email', 'phone_number', 'cpf', 'role', 'status'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {
+                'created' => "Usuário {$this->name} foi criado",
+                'updated' => "Usuário {$this->name} foi atualizado",
+                'deleted' => "Usuário {$this->name} foi removido",
+                default   => "Usuário {$this->name}: {$eventName}",
+            });
     }
 }

--- a/web/app/Providers/Filament/AdminPanelProvider.php
+++ b/web/app/Providers/Filament/AdminPanelProvider.php
@@ -67,7 +67,9 @@ class AdminPanelProvider extends PanelProvider
     {
         // Restrict Filament access to admin users only
         \Filament\Facades\Filament::serving(function (): void {
-            \Filament\Facades\Filament::auth()->check() && $this->authorizeAdmin();
+            if (\Filament\Facades\Filament::auth()->check()) {
+                $this->authorizeAdmin();
+            }
         });
     }
 

--- a/web/composer.json
+++ b/web/composer.json
@@ -13,7 +13,8 @@
         "laravel/framework": "^12.26",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10",
-        "league/csv": "^9.0"
+        "league/csv": "^9.0",
+        "spatie/laravel-activitylog": "^4.10"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3d39b1ee1e981db5c0062d9702c1708",
+    "content-hash": "f72b0b3ec02f9d8980c41a39f25585eb",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -5142,6 +5142,97 @@
                 }
             ],
             "time": "2024-05-17T09:06:10+00:00"
+        },
+        {
+            "name": "spatie/laravel-activitylog",
+            "version": "4.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-activitylog.git",
+                "reference": "bb879775d487438ed9a99e64f09086b608990c10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/bb879775d487438ed9a99e64f09086b608990c10",
+                "reference": "bb879775d487438ed9a99e64f09086b608990c10",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+                "illuminate/database": "^8.69 || ^9.27 || ^10.0 || ^11.0 || ^12.0",
+                "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+                "php": "^8.1",
+                "spatie/laravel-package-tools": "^1.6.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "orchestra/testbench": "^6.23 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+                "pestphp/pest": "^1.20 || ^2.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Activitylog\\ActivitylogServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Activitylog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A very simple activity logger to monitor the users of your website or application",
+            "homepage": "https://github.com/spatie/activitylog",
+            "keywords": [
+                "activity",
+                "laravel",
+                "log",
+                "spatie",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-activitylog/issues",
+                "source": "https://github.com/spatie/laravel-activitylog/tree/4.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-06-15T06:59:49+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",

--- a/web/config/activitylog.php
+++ b/web/config/activitylog.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+return [
+
+    /*
+     * If set to false, no activities will be saved to the database.
+     */
+    'enabled' => env('ACTIVITY_LOGGER_ENABLED', true),
+
+    /*
+     * When the clean-command is executed, all recording activities older than
+     * the number of days specified here will be deleted.
+     */
+    'delete_records_older_than_days' => 365,
+
+    /*
+     * If no log name is passed to the activity() helper
+     * we use this default log name.
+     */
+    'default_log_name' => 'default',
+
+    /*
+     * You can specify an auth driver here that gets user models.
+     * If this is null we'll use the current Laravel auth driver.
+     */
+    'default_auth_driver' => null,
+
+    /*
+     * If set to true, the subject returns soft deleted models.
+     */
+    'subject_returns_soft_deleted_models' => false,
+
+    /*
+     * This model will be used to log activity.
+     * It should implement the Spatie\Activitylog\Contracts\Activity interface
+     * and extend Illuminate\Database\Eloquent\Model.
+     */
+    'activity_model' => Spatie\Activitylog\Models\Activity::class,
+
+    /*
+     * This is the name of the table that will be created by the migration and
+     * used by the Activity model shipped with this package.
+     */
+    'table_name' => env('ACTIVITY_LOGGER_TABLE_NAME', 'activity_log'),
+
+    /*
+     * This is the database connection that will be used by the migration and
+     * the Activity model shipped with this package. In case it's not set
+     * Laravel's database.default will be used instead.
+     */
+    'database_connection' => env('ACTIVITY_LOGGER_DB_CONNECTION'),
+];

--- a/web/database/migrations/2026_01_27_032915_create_activity_log_table.php
+++ b/web/database/migrations/2026_01_27_032915_create_activity_log_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateActivityLogTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))->create(config('activitylog.table_name'), function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('log_name')->nullable();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('properties')->nullable();
+            $table->timestamps();
+            $table->index('log_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))->dropIfExists(config('activitylog.table_name'));
+    }
+}

--- a/web/database/migrations/2026_01_27_032916_add_event_column_to_activity_log_table.php
+++ b/web/database/migrations/2026_01_27_032916_add_event_column_to_activity_log_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEventColumnToActivityLogTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table): void {
+            $table->string('event')->nullable()->after('subject_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table): void {
+            $table->dropColumn('event');
+        });
+    }
+}

--- a/web/database/migrations/2026_01_27_032917_add_batch_uuid_column_to_activity_log_table.php
+++ b/web/database/migrations/2026_01_27_032917_add_batch_uuid_column_to_activity_log_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddBatchUuidColumnToActivityLogTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table): void {
+            $table->uuid('batch_uuid')->nullable()->after('properties');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table): void {
+            $table->dropColumn('batch_uuid');
+        });
+    }
+}

--- a/web/tests/Feature/ActivityLogTest.php
+++ b/web/tests/Feature/ActivityLogTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enums\UserStatus;
+use App\Models\Doctor;
+use App\Models\Drug;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+use Spatie\Activitylog\Models\Activity;
+
+beforeEach(function (): void {
+    Activity::query()->delete();
+});
+
+describe('User Activity Logging', function (): void {
+    it('logs when a user is created', function (): void {
+        $user = User::factory()->receptor()->create();
+
+        $activity = Activity::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->description)->toContain('foi criado');
+    });
+
+    it('logs when a user is updated', function (): void {
+        $user = User::factory()->receptor()->create(['name' => 'Old Name']);
+        Activity::query()->delete();
+
+        $user->update(['name' => 'New Name']);
+
+        $activity = Activity::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('event', 'updated')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->properties['old']['name'])->toBe('Old Name')
+            ->and($activity->properties['attributes']['name'])->toBe('New Name');
+    });
+
+    it('does not log when unchanged fields are saved', function (): void {
+        $user = User::factory()->receptor()->create(['name' => 'Same Name']);
+        Activity::query()->delete();
+
+        $user->update(['name' => 'Same Name']);
+
+        $activity = Activity::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('event', 'updated')
+            ->first();
+
+        expect($activity)->toBeNull();
+    });
+});
+
+describe('MedicationOffering Activity Logging', function (): void {
+    it('logs when a medication offering is created', function (): void {
+        $doctor = Doctor::factory()->create();
+        $drug   = Drug::factory()->create();
+
+        $offering = MedicationOffering::factory()->create([
+            'doctor_id' => $doctor->id,
+            'drug_id'   => $drug->id,
+        ]);
+
+        $activity = Activity::where('subject_type', MedicationOffering::class)
+            ->where('subject_id', $offering->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->description)->toContain('criada');
+    });
+
+    it('logs when a medication offering status changes', function (): void {
+        $offering = MedicationOffering::factory()->create(['status' => 'available']);
+        Activity::query()->delete();
+
+        $offering->update(['status' => 'reserved']);
+
+        $activity = Activity::where('subject_type', MedicationOffering::class)
+            ->where('subject_id', $offering->id)
+            ->where('event', 'updated')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->properties['old']['status'])->toBe('available')
+            ->and($activity->properties['attributes']['status'])->toBe('reserved');
+    });
+});
+
+describe('MedicationRequest Activity Logging', function (): void {
+    it('logs when a medication request is created', function (): void {
+        $receptor = User::factory()->receptor()->create(['status' => UserStatus::Approved]);
+        $offering = MedicationOffering::factory()->available()->create();
+        Activity::query()->delete();
+
+        $request = MedicationRequest::create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'pending',
+        ]);
+
+        $activity = Activity::where('subject_type', MedicationRequest::class)
+            ->where('subject_id', $request->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->description)->toContain('criada');
+    });
+
+    it('logs when a medication request status changes', function (): void {
+        $request = MedicationRequest::factory()->pending()->create();
+        Activity::query()->delete();
+
+        $request->update(['status' => 'confirmed']);
+
+        $activity = Activity::where('subject_type', MedicationRequest::class)
+            ->where('subject_id', $request->id)
+            ->where('event', 'updated')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->properties['old']['status'])->toBe('pending')
+            ->and($activity->properties['attributes']['status'])->toBe('confirmed');
+    });
+});
+
+describe('Activity Log Causer Tracking', function (): void {
+    it('tracks the user who made the change', function (): void {
+        $admin = User::factory()->admin()->create();
+        auth()->login($admin);
+
+        $user = User::factory()->receptor()->create();
+
+        $activity = Activity::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->causer_id)->toBe($admin->id)
+            ->and($activity->causer_type)->toBe(User::class);
+
+        auth()->logout();
+    });
+});


### PR DESCRIPTION
## Summary

Implementa sistema de monitoramento de atividades para o painel administrativo usando **spatie/laravel-activitylog**.

**Funcionalidades:**
- Activity logging automático em models de domínio (User, MedicationOffering, MedicationRequest, MedicationAppointment)
- Eventos customizados para aprovação/rejeição de usuários
- ActivityLogResource no Filament para visualizar todos os logs
- Widgets no dashboard: estatísticas e atividades recentes
- Tracking de quem (causer) fez cada mudança

**Documentação:**
- `docs/ACTIVITY_LOGGING.md` - Arquitetura completa e guia de uso
- `docs/CONVENTIONS.md` - Atualizado com regras para novos models
- `docs/DECISIONS.md` - D13 documentando escolha do Spatie Activity Log

**Commits organizados:**
1. `chore(web): add spatie/laravel-activitylog package` - Instalação do pacote
2. `feat(web): add activity_log database migrations` - Migrações
3. `feat(web): enable activity logging on core domain models` - Traits nos models
4. `feat(web): add ActivityLogResource to Filament admin panel` - Interface admin
5. `feat(web): add activity monitoring dashboard widgets` - Widgets
6. `feat(web): log custom events for user approval/rejection` - Eventos customizados
7. `test(web): add tests for activity logging functionality` - Testes
8. `docs: add D13 decision for Spatie Activity Log` - Decisão arquitetural
9. `docs: add activity logging documentation and best practices` - Documentação completa

## Test plan

- [x] Testes automatizados: 454 testes passando (8 novos para activity log)
- [x] PHPStan sem erros
- [ ] Testar criação de usuário e verificar log
- [ ] Testar aprovação de usuário e verificar evento "approved"
- [ ] Testar dashboard widgets (stats e recent activities)
- [ ] Verificar filtros no ActivityLogResource

## Issue

Closes #67