### PR TITLE
feat(web): add admin reports dashboard with analytics

### DIFF
--- a/web/app/Filament/Pages/Reports.php
+++ b/web/app/Filament/Pages/Reports.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Pages;
+
+use App\Models\MedicationAppointment;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use Filament\Pages\Page;
+
+class Reports extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
+
+    protected static string $view = 'filament.pages.reports';
+
+    protected static ?string $navigationLabel = 'Relatórios';
+
+    protected static ?string $title = 'Relatórios e Métricas';
+
+    protected static ?string $navigationGroup = 'Monitoramento';
+
+    protected static ?int $navigationSort = 2;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function getViewData(): array
+    {
+        return [
+            'offeringsData'  => $this->getOfferingsChartData(),
+            'requestsData'   => $this->getRequestsChartData(),
+            'statusData'     => $this->getStatusDistributionData(),
+            'monthlyData'    => $this->getMonthlyDonationsData(),
+            'summaryMetrics' => $this->getSummaryMetrics(),
+        ];
+    }
+
+    /**
+     * @return array{labels: array<string>, data: array<int>}
+     */
+    private function getOfferingsChartData(): array
+    {
+        $labels = [];
+        $data   = [];
+
+        for ($i = 6; $i >= 0; $i--) {
+            $date     = now()->subDays($i);
+            $labels[] = $date->format('d/m');
+            $data[]   = MedicationOffering::whereDate('created_at', $date->toDateString())->count();
+        }
+
+        return [
+            'labels' => $labels,
+            'data'   => $data,
+        ];
+    }
+
+    /**
+     * @return array{labels: array<string>, data: array<int>}
+     */
+    private function getRequestsChartData(): array
+    {
+        $labels = [];
+        $data   = [];
+
+        for ($i = 6; $i >= 0; $i--) {
+            $date     = now()->subDays($i);
+            $labels[] = $date->format('d/m');
+            $data[]   = MedicationRequest::whereDate('created_at', $date->toDateString())->count();
+        }
+
+        return [
+            'labels' => $labels,
+            'data'   => $data,
+        ];
+    }
+
+    /**
+     * @return array{labels: array<string>, data: array<int>, colors: array<string>}
+     */
+    private function getStatusDistributionData(): array
+    {
+        return [
+            'labels' => ['Disponíveis', 'Reservados', 'Concluídos'],
+            'data'   => [
+                MedicationOffering::available()->count(),
+                MedicationOffering::reserved()->count(),
+                MedicationOffering::completed()->count(),
+            ],
+            'colors' => ['#22c55e', '#eab308', '#3b82f6'],
+        ];
+    }
+
+    /**
+     * @return array{labels: array<string>, offerings: array<int>, completions: array<int>}
+     */
+    private function getMonthlyDonationsData(): array
+    {
+        $labels      = [];
+        $offerings   = [];
+        $completions = [];
+
+        for ($i = 5; $i >= 0; $i--) {
+            $date       = now()->subMonths($i);
+            $monthStart = $date->copy()->startOfMonth();
+            $monthEnd   = $date->copy()->endOfMonth();
+
+            $labels[]      = $date->translatedFormat('M/Y');
+            $offerings[]   = MedicationOffering::whereBetween('created_at', [$monthStart, $monthEnd])->count();
+            $completions[] = MedicationAppointment::completed()
+                ->whereBetween('updated_at', [$monthStart, $monthEnd])
+                ->count();
+        }
+
+        return [
+            'labels'      => $labels,
+            'offerings'   => $offerings,
+            'completions' => $completions,
+        ];
+    }
+
+    /**
+     * @return array<string, int|float|string>
+     */
+    private function getSummaryMetrics(): array
+    {
+        $totalOfferings        = MedicationOffering::count();
+        $completedOfferings    = MedicationOffering::completed()->count();
+        $totalQuantity         = (int) MedicationOffering::sum('quantity');
+        $completedAppointments = MedicationAppointment::completed()->count();
+
+        $completionRate = $totalOfferings > 0
+            ? round(($completedOfferings / $totalOfferings) * 100, 1)
+            : 0;
+
+        $thisMonth    = now()->startOfMonth();
+        $lastMonth    = now()->subMonth()->startOfMonth();
+        $lastMonthEnd = now()->subMonth()->endOfMonth();
+
+        $offeringsThisMonth = MedicationOffering::where('created_at', '>=', $thisMonth)->count();
+        $offeringsLastMonth = MedicationOffering::whereBetween('created_at', [$lastMonth, $lastMonthEnd])->count();
+
+        $growthRate = $offeringsLastMonth > 0
+            ? round((($offeringsThisMonth - $offeringsLastMonth) / $offeringsLastMonth) * 100, 1)
+            : ($offeringsThisMonth > 0 ? 100 : 0);
+
+        return [
+            'totalOfferings'        => $totalOfferings,
+            'completedOfferings'    => $completedOfferings,
+            'completionRate'        => $completionRate,
+            'totalQuantity'         => number_format($totalQuantity, 0, ',', '.'),
+            'completedAppointments' => $completedAppointments,
+            'offeringsThisMonth'    => $offeringsThisMonth,
+            'growthRate'            => $growthRate,
+            'growthRateFormatted'   => ($growthRate >= 0 ? '+' : '') . $growthRate . '%',
+        ];
+    }
+}

--- a/web/app/Filament/Resources/MedicationAppointmentResource.php
+++ b/web/app/Filament/Resources/MedicationAppointmentResource.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MedicationAppointmentResource\Pages;
+use App\Models\MedicationAppointment;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class MedicationAppointmentResource extends Resource
+{
+    protected static ?string $model = MedicationAppointment::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-calendar';
+
+    protected static ?string $modelLabel = 'Agendamento';
+
+    protected static ?string $pluralModelLabel = 'Agendamentos';
+
+    protected static ?string $navigationGroup = 'Doações';
+
+    protected static ?int $navigationSort = 3;
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('medicationRequest.receptor.name')
+                    ->label('Receptor')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('medicationRequest.medicationOffering.doctor.user.name')
+                    ->label('Médico')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('medicationRequest.medicationOffering.drug.product_name')
+                    ->label('Medicamento')
+                    ->limit(20)
+                    ->tooltip(fn (MedicationAppointment $record): string => $record->medicationRequest->medicationOffering->drug->product_name ?? ''),
+                Tables\Columns\TextColumn::make('scheduled_date')
+                    ->label('Data')
+                    ->date('d/m/Y')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('scheduled_time')
+                    ->label('Hora')
+                    ->time('H:i'),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'proposed'  => 'Proposto',
+                        'confirmed' => 'Confirmado',
+                        'completed' => 'Concluído',
+                        default     => $state,
+                    })
+                    ->color(fn (string $state): string => match ($state) {
+                        'proposed'  => 'warning',
+                        'confirmed' => 'info',
+                        'completed' => 'success',
+                        default     => 'gray',
+                    }),
+                Tables\Columns\IconColumn::make('receptor_confirmed')
+                    ->label('Receptor OK')
+                    ->boolean(),
+                Tables\Columns\IconColumn::make('doctor_confirmed')
+                    ->label('Médico OK')
+                    ->boolean(),
+            ])
+            ->defaultSort('scheduled_date', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->label('Status')
+                    ->options([
+                        'proposed'  => 'Proposto',
+                        'confirmed' => 'Confirmado',
+                        'completed' => 'Concluído',
+                    ]),
+                Tables\Filters\Filter::make('upcoming')
+                    ->label('Futuros')
+                    ->query(fn (Builder $query): Builder => $query
+                        ->where('scheduled_date', '>=', now()->toDateString())),
+                Tables\Filters\Filter::make('past')
+                    ->label('Passados')
+                    ->query(fn (Builder $query): Builder => $query
+                        ->where('scheduled_date', '<', now()->toDateString())),
+                Tables\Filters\Filter::make('scheduled_date')
+                    ->form([
+                        \Filament\Forms\Components\DatePicker::make('from')
+                            ->label('De'),
+                        \Filament\Forms\Components\DatePicker::make('until')
+                            ->label('Até'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when(
+                            $data['from'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('scheduled_date', '>=', $date),
+                        )
+                        ->when(
+                            $data['until'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('scheduled_date', '<=', $date),
+                        )),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    #[\Override]
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Informações do Agendamento')
+                    ->schema([
+                        TextEntry::make('id')
+                            ->label('ID'),
+                        TextEntry::make('scheduled_date')
+                            ->label('Data')
+                            ->date('d/m/Y'),
+                        TextEntry::make('scheduled_time')
+                            ->label('Hora')
+                            ->time('H:i'),
+                        TextEntry::make('status')
+                            ->label('Status')
+                            ->badge()
+                            ->formatStateUsing(fn (string $state): string => match ($state) {
+                                'proposed'  => 'Proposto',
+                                'confirmed' => 'Confirmado',
+                                'completed' => 'Concluído',
+                                default     => $state,
+                            })
+                            ->color(fn (string $state): string => match ($state) {
+                                'proposed'  => 'warning',
+                                'confirmed' => 'info',
+                                'completed' => 'success',
+                                default     => 'gray',
+                            }),
+                        TextEntry::make('proposed_by')
+                            ->label('Proposto por')
+                            ->formatStateUsing(fn (string $state): string => match ($state) {
+                                'receptor' => 'Receptor',
+                                'doctor'   => 'Médico',
+                                default    => $state,
+                            }),
+                    ])
+                    ->columns(3),
+                Section::make('Confirmações')
+                    ->schema([
+                        TextEntry::make('receptor_confirmed')
+                            ->label('Receptor Confirmou')
+                            ->formatStateUsing(fn (bool $state): string => $state ? 'Sim' : 'Não')
+                            ->badge()
+                            ->color(fn (bool $state): string => $state ? 'success' : 'gray'),
+                        TextEntry::make('doctor_confirmed')
+                            ->label('Médico Confirmou')
+                            ->formatStateUsing(fn (bool $state): string => $state ? 'Sim' : 'Não')
+                            ->badge()
+                            ->color(fn (bool $state): string => $state ? 'success' : 'gray'),
+                    ])
+                    ->columns(2),
+                Section::make('Local')
+                    ->schema([
+                        TextEntry::make('address.location_name')
+                            ->label('Nome do Local'),
+                        TextEntry::make('address.full_address')
+                            ->label('Endereço'),
+                        TextEntry::make('address.complement')
+                            ->label('Complemento'),
+                        TextEntry::make('address.cep')
+                            ->label('CEP'),
+                    ])
+                    ->columns(2),
+                Section::make('Receptor')
+                    ->schema([
+                        TextEntry::make('medicationRequest.receptor.name')
+                            ->label('Nome'),
+                        TextEntry::make('medicationRequest.receptor.email')
+                            ->label('E-mail'),
+                        TextEntry::make('medicationRequest.receptor.phone_number')
+                            ->label('Telefone'),
+                    ])
+                    ->columns(3),
+                Section::make('Médico')
+                    ->schema([
+                        TextEntry::make('medicationRequest.medicationOffering.doctor.user.name')
+                            ->label('Nome'),
+                        TextEntry::make('medicationRequest.medicationOffering.doctor.crm')
+                            ->label('CRM')
+                            ->formatStateUsing(fn (MedicationAppointment $record): string => "{$record->medicationRequest->medicationOffering->doctor->crm}/{$record->medicationRequest->medicationOffering->doctor->crm_uf}"),
+                        TextEntry::make('medicationRequest.medicationOffering.doctor.user.phone_number')
+                            ->label('Telefone'),
+                    ])
+                    ->columns(3),
+                Section::make('Medicamento')
+                    ->schema([
+                        TextEntry::make('medicationRequest.medicationOffering.drug.product_name')
+                            ->label('Medicamento'),
+                        TextEntry::make('medicationRequest.medicationOffering.drug.substance')
+                            ->label('Princípio Ativo'),
+                        TextEntry::make('medicationRequest.medicationOffering.lot_number')
+                            ->label('Lote'),
+                        TextEntry::make('medicationRequest.medicationOffering.quantity')
+                            ->label('Quantidade'),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMedicationAppointments::route('/'),
+            'view'  => Pages\ViewMedicationAppointment::route('/{record}'),
+        ];
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getModel()::confirmed()
+            ->where('scheduled_date', '>=', now()->toDateString())
+            ->count();
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'info';
+    }
+}

--- a/web/app/Filament/Resources/MedicationAppointmentResource/Pages/ListMedicationAppointments.php
+++ b/web/app/Filament/Resources/MedicationAppointmentResource/Pages/ListMedicationAppointments.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\MedicationAppointmentResource\Pages;
+
+use App\Filament\Resources\MedicationAppointmentResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMedicationAppointments extends ListRecords
+{
+    protected static string $resource = MedicationAppointmentResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/web/app/Filament/Resources/MedicationAppointmentResource/Pages/ViewMedicationAppointment.php
+++ b/web/app/Filament/Resources/MedicationAppointmentResource/Pages/ViewMedicationAppointment.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\MedicationAppointmentResource\Pages;
+
+use App\Filament\Resources\MedicationAppointmentResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewMedicationAppointment extends ViewRecord
+{
+    protected static string $resource = MedicationAppointmentResource::class;
+}

--- a/web/app/Filament/Resources/MedicationOfferingResource.php
+++ b/web/app/Filament/Resources/MedicationOfferingResource.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MedicationOfferingResource\Pages;
+use App\Models\MedicationOffering;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class MedicationOfferingResource extends Resource
+{
+    protected static ?string $model = MedicationOffering::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-archive-box';
+
+    protected static ?string $modelLabel = 'Oferta de Medicamento';
+
+    protected static ?string $pluralModelLabel = 'Ofertas de Medicamentos';
+
+    protected static ?string $navigationGroup = 'Doações';
+
+    protected static ?int $navigationSort = 1;
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('drug.product_name')
+                    ->label('Medicamento')
+                    ->limit(30)
+                    ->tooltip(fn (MedicationOffering $record): string => $record->drug->product_name ?? '')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('doctor.user.name')
+                    ->label('Médico')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('lot_number')
+                    ->label('Lote')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->label('Validade')
+                    ->date('d/m/Y')
+                    ->sortable()
+                    ->color(fn (MedicationOffering $record): string => $record->expires_at->isPast() ? 'danger' : ($record->expires_at->diffInDays(now()) <= 30 ? 'warning' : 'success')),
+                Tables\Columns\TextColumn::make('quantity')
+                    ->label('Quantidade')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'available' => 'Disponível',
+                        'reserved'  => 'Reservado',
+                        'completed' => 'Concluído',
+                        default     => $state,
+                    })
+                    ->color(fn (string $state): string => match ($state) {
+                        'available' => 'success',
+                        'reserved'  => 'warning',
+                        'completed' => 'info',
+                        default     => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Cadastrado em')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->label('Status')
+                    ->options([
+                        'available' => 'Disponível',
+                        'reserved'  => 'Reservado',
+                        'completed' => 'Concluído',
+                    ]),
+                Tables\Filters\Filter::make('expiring_soon')
+                    ->label('Vencendo em 30 dias')
+                    ->query(fn (Builder $query): Builder => $query
+                        ->where('expires_at', '<=', now()->addDays(30))
+                        ->where('expires_at', '>', now())),
+                Tables\Filters\Filter::make('expired')
+                    ->label('Vencidos')
+                    ->query(fn (Builder $query): Builder => $query
+                        ->where('expires_at', '<', now())),
+                Tables\Filters\Filter::make('created_at')
+                    ->form([
+                        \Filament\Forms\Components\DatePicker::make('from')
+                            ->label('De'),
+                        \Filament\Forms\Components\DatePicker::make('until')
+                            ->label('Até'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when(
+                            $data['from'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('created_at', '>=', $date),
+                        )
+                        ->when(
+                            $data['until'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('created_at', '<=', $date),
+                        )),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    #[\Override]
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Informações do Medicamento')
+                    ->schema([
+                        TextEntry::make('drug.product_name')
+                            ->label('Medicamento'),
+                        TextEntry::make('drug.substance')
+                            ->label('Princípio Ativo'),
+                        TextEntry::make('drug.laboratory')
+                            ->label('Laboratório'),
+                        TextEntry::make('drug.presentation')
+                            ->label('Apresentação'),
+                    ])
+                    ->columns(2),
+                Section::make('Informações da Oferta')
+                    ->schema([
+                        TextEntry::make('lot_number')
+                            ->label('Lote'),
+                        TextEntry::make('expires_at')
+                            ->label('Validade')
+                            ->date('d/m/Y'),
+                        TextEntry::make('quantity')
+                            ->label('Quantidade'),
+                        TextEntry::make('status')
+                            ->label('Status')
+                            ->badge()
+                            ->formatStateUsing(fn (string $state): string => match ($state) {
+                                'available' => 'Disponível',
+                                'reserved'  => 'Reservado',
+                                'completed' => 'Concluído',
+                                default     => $state,
+                            })
+                            ->color(fn (string $state): string => match ($state) {
+                                'available' => 'success',
+                                'reserved'  => 'warning',
+                                'completed' => 'info',
+                                default     => 'gray',
+                            }),
+                    ])
+                    ->columns(2),
+                Section::make('Médico Doador')
+                    ->schema([
+                        TextEntry::make('doctor.user.name')
+                            ->label('Nome'),
+                        TextEntry::make('doctor.crm')
+                            ->label('CRM')
+                            ->formatStateUsing(fn (MedicationOffering $record): string => "{$record->doctor->crm}/{$record->doctor->crm_uf}"),
+                        TextEntry::make('doctor.user.email')
+                            ->label('E-mail'),
+                        TextEntry::make('doctor.user.phone_number')
+                            ->label('Telefone'),
+                    ])
+                    ->columns(2),
+                Section::make('Registro')
+                    ->schema([
+                        TextEntry::make('created_at')
+                            ->label('Cadastrado em')
+                            ->dateTime('d/m/Y H:i:s'),
+                        TextEntry::make('updated_at')
+                            ->label('Atualizado em')
+                            ->dateTime('d/m/Y H:i:s'),
+                    ])
+                    ->columns(2)
+                    ->collapsed(),
+            ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMedicationOfferings::route('/'),
+            'view'  => Pages\ViewMedicationOffering::route('/{record}'),
+        ];
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getModel()::available()->count();
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'success';
+    }
+}

--- a/web/app/Filament/Resources/MedicationOfferingResource/Pages/ListMedicationOfferings.php
+++ b/web/app/Filament/Resources/MedicationOfferingResource/Pages/ListMedicationOfferings.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\MedicationOfferingResource\Pages;
+
+use App\Filament\Resources\MedicationOfferingResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMedicationOfferings extends ListRecords
+{
+    protected static string $resource = MedicationOfferingResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/web/app/Filament/Resources/MedicationOfferingResource/Pages/ViewMedicationOffering.php
+++ b/web/app/Filament/Resources/MedicationOfferingResource/Pages/ViewMedicationOffering.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\MedicationOfferingResource\Pages;
+
+use App\Filament\Resources\MedicationOfferingResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewMedicationOffering extends ViewRecord
+{
+    protected static string $resource = MedicationOfferingResource::class;
+}

--- a/web/app/Filament/Resources/MedicationRequestResource.php
+++ b/web/app/Filament/Resources/MedicationRequestResource.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MedicationRequestResource\Pages;
+use App\Models\MedicationRequest;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class MedicationRequestResource extends Resource
+{
+    protected static ?string $model = MedicationRequest::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-check';
+
+    protected static ?string $modelLabel = 'Solicitação';
+
+    protected static ?string $pluralModelLabel = 'Solicitações';
+
+    protected static ?string $navigationGroup = 'Doações';
+
+    protected static ?int $navigationSort = 2;
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('receptor.name')
+                    ->label('Receptor')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('medicationOffering.drug.product_name')
+                    ->label('Medicamento')
+                    ->limit(25)
+                    ->tooltip(fn (MedicationRequest $record): string => $record->medicationOffering->drug->product_name ?? '')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('medicationOffering.doctor.user.name')
+                    ->label('Médico')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'pending'   => 'Pendente',
+                        'confirmed' => 'Confirmada',
+                        'rejected'  => 'Rejeitada',
+                        default     => $state,
+                    })
+                    ->color(fn (string $state): string => match ($state) {
+                        'pending'   => 'warning',
+                        'confirmed' => 'success',
+                        'rejected'  => 'danger',
+                        default     => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Solicitado em')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->label('Status')
+                    ->options([
+                        'pending'   => 'Pendente',
+                        'confirmed' => 'Confirmada',
+                        'rejected'  => 'Rejeitada',
+                    ]),
+                Tables\Filters\Filter::make('created_at')
+                    ->form([
+                        \Filament\Forms\Components\DatePicker::make('from')
+                            ->label('De'),
+                        \Filament\Forms\Components\DatePicker::make('until')
+                            ->label('Até'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when(
+                            $data['from'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('created_at', '>=', $date),
+                        )
+                        ->when(
+                            $data['until'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('created_at', '<=', $date),
+                        )),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    #[\Override]
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Informações da Solicitação')
+                    ->schema([
+                        TextEntry::make('id')
+                            ->label('ID'),
+                        TextEntry::make('status')
+                            ->label('Status')
+                            ->badge()
+                            ->formatStateUsing(fn (string $state): string => match ($state) {
+                                'pending'   => 'Pendente',
+                                'confirmed' => 'Confirmada',
+                                'rejected'  => 'Rejeitada',
+                                default     => $state,
+                            })
+                            ->color(fn (string $state): string => match ($state) {
+                                'pending'   => 'warning',
+                                'confirmed' => 'success',
+                                'rejected'  => 'danger',
+                                default     => 'gray',
+                            }),
+                        TextEntry::make('created_at')
+                            ->label('Solicitado em')
+                            ->dateTime('d/m/Y H:i:s'),
+                        TextEntry::make('updated_at')
+                            ->label('Atualizado em')
+                            ->dateTime('d/m/Y H:i:s'),
+                    ])
+                    ->columns(2),
+                Section::make('Receptor')
+                    ->schema([
+                        TextEntry::make('receptor.name')
+                            ->label('Nome'),
+                        TextEntry::make('receptor.email')
+                            ->label('E-mail'),
+                        TextEntry::make('receptor.phone_number')
+                            ->label('Telefone'),
+                        TextEntry::make('receptor.cpf')
+                            ->label('CPF'),
+                    ])
+                    ->columns(2),
+                Section::make('Oferta de Medicamento')
+                    ->schema([
+                        TextEntry::make('medicationOffering.drug.product_name')
+                            ->label('Medicamento'),
+                        TextEntry::make('medicationOffering.drug.substance')
+                            ->label('Princípio Ativo'),
+                        TextEntry::make('medicationOffering.lot_number')
+                            ->label('Lote'),
+                        TextEntry::make('medicationOffering.expires_at')
+                            ->label('Validade')
+                            ->date('d/m/Y'),
+                        TextEntry::make('medicationOffering.quantity')
+                            ->label('Quantidade'),
+                        TextEntry::make('medicationOffering.status')
+                            ->label('Status da Oferta')
+                            ->badge()
+                            ->formatStateUsing(fn (string $state): string => match ($state) {
+                                'available' => 'Disponível',
+                                'reserved'  => 'Reservado',
+                                'completed' => 'Concluído',
+                                default     => $state,
+                            }),
+                    ])
+                    ->columns(2),
+                Section::make('Médico Doador')
+                    ->schema([
+                        TextEntry::make('medicationOffering.doctor.user.name')
+                            ->label('Nome'),
+                        TextEntry::make('medicationOffering.doctor.crm')
+                            ->label('CRM')
+                            ->formatStateUsing(fn (MedicationRequest $record): string => "{$record->medicationOffering->doctor->crm}/{$record->medicationOffering->doctor->crm_uf}"),
+                        TextEntry::make('medicationOffering.doctor.user.email')
+                            ->label('E-mail'),
+                        TextEntry::make('medicationOffering.doctor.user.phone_number')
+                            ->label('Telefone'),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMedicationRequests::route('/'),
+            'view'  => Pages\ViewMedicationRequest::route('/{record}'),
+        ];
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getModel()::pending()->count();
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        $count = static::getModel()::pending()->count();
+
+        return $count > 0 ? 'warning' : 'success';
+    }
+}

--- a/web/app/Filament/Resources/MedicationRequestResource/Pages/ListMedicationRequests.php
+++ b/web/app/Filament/Resources/MedicationRequestResource/Pages/ListMedicationRequests.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\MedicationRequestResource\Pages;
+
+use App\Filament\Resources\MedicationRequestResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMedicationRequests extends ListRecords
+{
+    protected static string $resource = MedicationRequestResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/web/app/Filament/Resources/MedicationRequestResource/Pages/ViewMedicationRequest.php
+++ b/web/app/Filament/Resources/MedicationRequestResource/Pages/ViewMedicationRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Resources\MedicationRequestResource\Pages;
+
+use App\Filament\Resources\MedicationRequestResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewMedicationRequest extends ViewRecord
+{
+    protected static string $resource = MedicationRequestResource::class;
+}

--- a/web/app/Filament/Widgets/DonationStatsWidget.php
+++ b/web/app/Filament/Widgets/DonationStatsWidget.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Widgets;
+
+use App\Models\MedicationOffering;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class DonationStatsWidget extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    protected static ?string $pollingInterval = '30s';
+
+    #[\Override]
+    protected function getStats(): array
+    {
+        $totalOfferings     = MedicationOffering::count();
+        $availableOfferings = MedicationOffering::available()->count();
+        $completedOfferings = MedicationOffering::completed()->count();
+        $totalQuantity      = MedicationOffering::sum('quantity');
+
+        $completionRate = $totalOfferings > 0
+            ? round(($completedOfferings / $totalOfferings) * 100, 1)
+            : 0;
+
+        return [
+            Stat::make('Total de Ofertas', number_format($totalOfferings, 0, ',', '.'))
+                ->description('Medicamentos cadastrados')
+                ->descriptionIcon('heroicon-m-archive-box')
+                ->color('primary')
+                ->chart($this->getOfferingsChartData()),
+
+            Stat::make('Ofertas Disponíveis', number_format($availableOfferings, 0, ',', '.'))
+                ->description('Aguardando solicitação')
+                ->descriptionIcon('heroicon-m-check-circle')
+                ->color('success'),
+
+            Stat::make('Doações Concluídas', number_format($completedOfferings, 0, ',', '.'))
+                ->description("Taxa de sucesso: {$completionRate}%")
+                ->descriptionIcon('heroicon-m-hand-thumb-up')
+                ->color('info'),
+
+            Stat::make('Unidades Doadas', number_format((int) $totalQuantity, 0, ',', '.'))
+                ->description('Total de medicamentos')
+                ->descriptionIcon('heroicon-m-cube')
+                ->color('warning'),
+        ];
+    }
+
+    /**
+     * Get chart data for offerings over the last 7 days.
+     *
+     * @return array<int>
+     */
+    private function getOfferingsChartData(): array
+    {
+        $data = [];
+
+        for ($i = 6; $i >= 0; $i--) {
+            $date   = now()->subDays($i)->toDateString();
+            $data[] = MedicationOffering::whereDate('created_at', $date)->count();
+        }
+
+        return $data;
+    }
+}

--- a/web/app/Filament/Widgets/RequestStatsWidget.php
+++ b/web/app/Filament/Widgets/RequestStatsWidget.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Widgets;
+
+use App\Models\MedicationAppointment;
+use App\Models\MedicationRequest;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class RequestStatsWidget extends BaseWidget
+{
+    protected static ?int $sort = 2;
+
+    protected static ?string $pollingInterval = '30s';
+
+    #[\Override]
+    protected function getStats(): array
+    {
+        $pendingRequests   = MedicationRequest::pending()->count();
+        $confirmedRequests = MedicationRequest::confirmed()->count();
+
+        $upcomingAppointments = MedicationAppointment::confirmed()
+            ->where('scheduled_date', '>=', now()->toDateString())
+            ->count();
+
+        $completedAppointments = MedicationAppointment::completed()->count();
+
+        return [
+            Stat::make('Solicitações Pendentes', number_format($pendingRequests, 0, ',', '.'))
+                ->description('Aguardando resposta do médico')
+                ->descriptionIcon('heroicon-m-clock')
+                ->color($pendingRequests > 10 ? 'danger' : 'warning'),
+
+            Stat::make('Solicitações Confirmadas', number_format($confirmedRequests, 0, ',', '.'))
+                ->description('Aprovadas pelos médicos')
+                ->descriptionIcon('heroicon-m-check')
+                ->color('success'),
+
+            Stat::make('Agendamentos Futuros', number_format($upcomingAppointments, 0, ',', '.'))
+                ->description('Entregas programadas')
+                ->descriptionIcon('heroicon-m-calendar')
+                ->color('info'),
+
+            Stat::make('Entregas Realizadas', number_format($completedAppointments, 0, ',', '.'))
+                ->description('Doações finalizadas')
+                ->descriptionIcon('heroicon-m-gift')
+                ->color('success'),
+        ];
+    }
+}

--- a/web/app/Filament/Widgets/TopDoctorsWidget.php
+++ b/web/app/Filament/Widgets/TopDoctorsWidget.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Widgets;
+
+use App\Models\Doctor;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class TopDoctorsWidget extends BaseWidget
+{
+    protected static ?int $sort = 4;
+
+    protected int | string | array $columnSpan = 'half';
+
+    protected static ?string $heading = 'Médicos Mais Ativos';
+
+    protected static ?string $pollingInterval = '60s';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Doctor::query()
+                    ->whereHas('medicationOfferings')
+                    ->withCount(['medicationOfferings as total_offerings'])
+                    ->withSum('medicationOfferings', 'quantity')
+                    ->orderByDesc('total_offerings')
+                    ->limit(5)
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Médico')
+                    ->searchable(false)
+                    ->sortable(false),
+                Tables\Columns\TextColumn::make('crm')
+                    ->label('CRM')
+                    ->formatStateUsing(fn (Doctor $record): string => "{$record->crm}/{$record->crm_uf}"),
+                Tables\Columns\TextColumn::make('total_offerings')
+                    ->label('Ofertas')
+                    ->numeric()
+                    ->sortable(false)
+                    ->badge()
+                    ->color('success'),
+                Tables\Columns\TextColumn::make('medication_offerings_sum_quantity')
+                    ->label('Unidades')
+                    ->numeric()
+                    ->sortable(false),
+            ])
+            ->paginated(false);
+    }
+}

--- a/web/app/Filament/Widgets/TopDrugsWidget.php
+++ b/web/app/Filament/Widgets/TopDrugsWidget.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Filament\Widgets;
+
+use App\Models\Drug;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class TopDrugsWidget extends BaseWidget
+{
+    protected static ?int $sort = 5;
+
+    protected int | string | array $columnSpan = 'half';
+
+    protected static ?string $heading = 'Medicamentos Mais Doados';
+
+    protected static ?string $pollingInterval = '60s';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Drug::query()
+                    ->whereHas('medicationOfferings')
+                    ->withCount(['medicationOfferings as total_offerings'])
+                    ->withSum('medicationOfferings', 'quantity')
+                    ->orderByDesc('medication_offerings_sum_quantity')
+                    ->limit(5)
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('product_name')
+                    ->label('Medicamento')
+                    ->limit(30)
+                    ->tooltip(fn (Drug $record): string => $record->product_name)
+                    ->searchable(false)
+                    ->sortable(false),
+                Tables\Columns\TextColumn::make('substance')
+                    ->label('Princípio Ativo')
+                    ->limit(20)
+                    ->sortable(false),
+                Tables\Columns\TextColumn::make('total_offerings')
+                    ->label('Ofertas')
+                    ->numeric()
+                    ->sortable(false)
+                    ->badge()
+                    ->color('info'),
+                Tables\Columns\TextColumn::make('medication_offerings_sum_quantity')
+                    ->label('Unidades')
+                    ->numeric()
+                    ->sortable(false),
+            ])
+            ->paginated(false);
+    }
+}

--- a/web/resources/views/filament/pages/reports.blade.php
+++ b/web/resources/views/filament/pages/reports.blade.php
@@ -1,0 +1,204 @@
+<x-filament-panels::page>
+    {{-- Summary Cards --}}
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold text-primary-600">{{ $summaryMetrics['totalOfferings'] }}</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Total de Ofertas</div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold text-success-600">{{ $summaryMetrics['completedOfferings'] }}</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Doações Concluídas</div>
+                <div class="text-xs text-gray-400 mt-1">{{ $summaryMetrics['completionRate'] }}% taxa de sucesso</div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold text-info-600">{{ $summaryMetrics['totalQuantity'] }}</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Unidades Doadas</div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold {{ $summaryMetrics['growthRate'] >= 0 ? 'text-success-600' : 'text-danger-600' }}">
+                    {{ $summaryMetrics['growthRateFormatted'] }}
+                </div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Crescimento Mensal</div>
+                <div class="text-xs text-gray-400 mt-1">{{ $summaryMetrics['offeringsThisMonth'] }} ofertas este mês</div>
+            </div>
+        </x-filament::section>
+    </div>
+
+    {{-- Charts Row 1 --}}
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2 mb-6">
+        {{-- Offerings Last 7 Days --}}
+        <x-filament::section>
+            <x-slot name="heading">
+                <div class="flex items-center gap-2">
+                    <x-heroicon-o-archive-box class="h-5 w-5 text-primary-500" />
+                    Ofertas - Últimos 7 dias
+                </div>
+            </x-slot>
+            <div class="h-64">
+                <canvas id="offeringsChart"></canvas>
+            </div>
+        </x-filament::section>
+
+        {{-- Requests Last 7 Days --}}
+        <x-filament::section>
+            <x-slot name="heading">
+                <div class="flex items-center gap-2">
+                    <x-heroicon-o-clipboard-document-check class="h-5 w-5 text-warning-500" />
+                    Solicitações - Últimos 7 dias
+                </div>
+            </x-slot>
+            <div class="h-64">
+                <canvas id="requestsChart"></canvas>
+            </div>
+        </x-filament::section>
+    </div>
+
+    {{-- Charts Row 2 --}}
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2 mb-6">
+        {{-- Status Distribution --}}
+        <x-filament::section>
+            <x-slot name="heading">
+                <div class="flex items-center gap-2">
+                    <x-heroicon-o-chart-pie class="h-5 w-5 text-success-500" />
+                    Distribuição por Status
+                </div>
+            </x-slot>
+            <div class="h-64">
+                <canvas id="statusChart"></canvas>
+            </div>
+        </x-filament::section>
+
+        {{-- Monthly Trend --}}
+        <x-filament::section>
+            <x-slot name="heading">
+                <div class="flex items-center gap-2">
+                    <x-heroicon-o-arrow-trending-up class="h-5 w-5 text-info-500" />
+                    Tendência Mensal (6 meses)
+                </div>
+            </x-slot>
+            <div class="h-64">
+                <canvas id="monthlyChart"></canvas>
+            </div>
+        </x-filament::section>
+    </div>
+
+    {{-- Load Chart.js from CDN --}}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const isDarkMode = document.documentElement.classList.contains('dark');
+            const textColor = isDarkMode ? '#9ca3af' : '#6b7280';
+            const gridColor = isDarkMode ? '#374151' : '#e5e7eb';
+
+            const commonOptions = {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        labels: { color: textColor }
+                    }
+                },
+                scales: {
+                    x: {
+                        ticks: { color: textColor },
+                        grid: { color: gridColor }
+                    },
+                    y: {
+                        ticks: { color: textColor },
+                        grid: { color: gridColor },
+                        beginAtZero: true
+                    }
+                }
+            };
+
+            // Offerings Chart
+            new Chart(document.getElementById('offeringsChart'), {
+                type: 'line',
+                data: {
+                    labels: @json($offeringsData['labels']),
+                    datasets: [{
+                        label: 'Ofertas',
+                        data: @json($offeringsData['data']),
+                        borderColor: '#3b82f6',
+                        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                        fill: true,
+                        tension: 0.3
+                    }]
+                },
+                options: commonOptions
+            });
+
+            // Requests Chart
+            new Chart(document.getElementById('requestsChart'), {
+                type: 'line',
+                data: {
+                    labels: @json($requestsData['labels']),
+                    datasets: [{
+                        label: 'Solicitações',
+                        data: @json($requestsData['data']),
+                        borderColor: '#eab308',
+                        backgroundColor: 'rgba(234, 179, 8, 0.1)',
+                        fill: true,
+                        tension: 0.3
+                    }]
+                },
+                options: commonOptions
+            });
+
+            // Status Distribution Chart
+            new Chart(document.getElementById('statusChart'), {
+                type: 'doughnut',
+                data: {
+                    labels: @json($statusData['labels']),
+                    datasets: [{
+                        data: @json($statusData['data']),
+                        backgroundColor: @json($statusData['colors']),
+                        borderWidth: 0
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                            labels: { color: textColor }
+                        }
+                    }
+                }
+            });
+
+            // Monthly Trend Chart
+            new Chart(document.getElementById('monthlyChart'), {
+                type: 'bar',
+                data: {
+                    labels: @json($monthlyData['labels']),
+                    datasets: [
+                        {
+                            label: 'Ofertas Criadas',
+                            data: @json($monthlyData['offerings']),
+                            backgroundColor: '#3b82f6'
+                        },
+                        {
+                            label: 'Entregas Concluídas',
+                            data: @json($monthlyData['completions']),
+                            backgroundColor: '#22c55e'
+                        }
+                    ]
+                },
+                options: commonOptions
+            });
+        });
+    </script>
+</x-filament-panels::page>

--- a/web/tests/Feature/Filament/ReportsTest.php
+++ b/web/tests/Feature/Filament/ReportsTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enums\UserRole;
+use App\Enums\UserStatus;
+use App\Filament\Resources\MedicationAppointmentResource;
+use App\Filament\Resources\MedicationOfferingResource;
+use App\Filament\Resources\MedicationRequestResource;
+use App\Models\Address;
+use App\Models\Doctor;
+use App\Models\Drug;
+use App\Models\MedicationAppointment;
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+
+describe('Medication Offering Resource', function (): void {
+    it('shows correct navigation badge for available offerings', function (): void {
+        $doctor = Doctor::factory()->create();
+
+        MedicationOffering::factory()->count(5)->create([
+            'doctor_id' => $doctor->id,
+            'status'    => 'available',
+        ]);
+
+        MedicationOffering::factory()->count(3)->create([
+            'doctor_id' => $doctor->id,
+            'status'    => 'completed',
+        ]);
+
+        expect(MedicationOfferingResource::getNavigationBadge())->toBe('5');
+        expect(MedicationOfferingResource::getNavigationBadgeColor())->toBe('success');
+    });
+
+    it('shows zero badge when no available offerings', function (): void {
+        expect(MedicationOfferingResource::getNavigationBadge())->toBe('0');
+    });
+
+    it('cannot create offerings from admin panel', function (): void {
+        expect(MedicationOfferingResource::canCreate())->toBeFalse();
+    });
+
+    it('cannot edit offerings from admin panel', function (): void {
+        $doctor   = Doctor::factory()->create();
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+
+        expect(MedicationOfferingResource::canEdit($offering))->toBeFalse();
+    });
+
+    it('cannot delete offerings from admin panel', function (): void {
+        $doctor   = Doctor::factory()->create();
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+
+        expect(MedicationOfferingResource::canDelete($offering))->toBeFalse();
+    });
+});
+
+describe('Medication Request Resource', function (): void {
+    it('shows navigation badge for pending requests', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+
+        MedicationRequest::factory()->count(3)->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'pending',
+        ]);
+
+        expect(MedicationRequestResource::getNavigationBadge())->toBe('3');
+        expect(MedicationRequestResource::getNavigationBadgeColor())->toBe('warning');
+    });
+
+    it('shows green badge when no pending requests', function (): void {
+        expect(MedicationRequestResource::getNavigationBadge())->toBe('0');
+        expect(MedicationRequestResource::getNavigationBadgeColor())->toBe('success');
+    });
+
+    it('cannot create requests from admin panel', function (): void {
+        expect(MedicationRequestResource::canCreate())->toBeFalse();
+    });
+
+    it('cannot edit requests from admin panel', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+        $request  = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+        ]);
+
+        expect(MedicationRequestResource::canEdit($request))->toBeFalse();
+    });
+});
+
+describe('Medication Appointment Resource', function (): void {
+    it('shows navigation badge for upcoming confirmed appointments', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $address  = Address::factory()->create(['user_id' => $doctor->user_id]);
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+
+        $request1 = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+        ]);
+
+        $request2 = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => MedicationOffering::factory()->create(['doctor_id' => $doctor->id])->id,
+        ]);
+
+        MedicationAppointment::factory()->create([
+            'medication_request_id' => $request1->id,
+            'address_id'            => $address->id,
+            'status'                => 'confirmed',
+            'scheduled_date'        => now()->addDays(5),
+        ]);
+
+        MedicationAppointment::factory()->create([
+            'medication_request_id' => $request2->id,
+            'address_id'            => $address->id,
+            'status'                => 'confirmed',
+            'scheduled_date'        => now()->addDays(10),
+        ]);
+
+        expect(MedicationAppointmentResource::getNavigationBadge())->toBe('2');
+        expect(MedicationAppointmentResource::getNavigationBadgeColor())->toBe('info');
+    });
+
+    it('shows zero badge when no upcoming appointments', function (): void {
+        expect(MedicationAppointmentResource::getNavigationBadge())->toBe('0');
+    });
+
+    it('does not count past appointments in badge', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $address  = Address::factory()->create(['user_id' => $doctor->user_id]);
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+
+        $request = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+        ]);
+
+        MedicationAppointment::factory()->create([
+            'medication_request_id' => $request->id,
+            'address_id'            => $address->id,
+            'status'                => 'confirmed',
+            'scheduled_date'        => now()->subDays(5),
+        ]);
+
+        expect(MedicationAppointmentResource::getNavigationBadge())->toBe('0');
+    });
+
+    it('cannot create appointments from admin panel', function (): void {
+        expect(MedicationAppointmentResource::canCreate())->toBeFalse();
+    });
+
+    it('cannot edit appointments from admin panel', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $address  = Address::factory()->create(['user_id' => $doctor->user_id]);
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+        $request  = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+        ]);
+        $appointment = MedicationAppointment::factory()->create([
+            'medication_request_id' => $request->id,
+            'address_id'            => $address->id,
+        ]);
+
+        expect(MedicationAppointmentResource::canEdit($appointment))->toBeFalse();
+    });
+});
+
+describe('Reports Page Data Calculations', function (): void {
+    it('calculates offerings correctly', function (): void {
+        $doctor = Doctor::factory()->create();
+
+        MedicationOffering::factory()->count(5)->create([
+            'doctor_id' => $doctor->id,
+            'status'    => 'available',
+            'quantity'  => 10,
+        ]);
+
+        MedicationOffering::factory()->count(3)->create([
+            'doctor_id' => $doctor->id,
+            'status'    => 'completed',
+            'quantity'  => 20,
+        ]);
+
+        expect(MedicationOffering::count())->toBe(8);
+        expect(MedicationOffering::available()->count())->toBe(5);
+        expect(MedicationOffering::completed()->count())->toBe(3);
+        expect((int) MedicationOffering::sum('quantity'))->toBe(110);
+    });
+
+    it('calculates requests correctly', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+
+        MedicationRequest::factory()->count(3)->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'pending',
+        ]);
+
+        MedicationRequest::factory()->count(2)->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'confirmed',
+        ]);
+
+        expect(MedicationRequest::pending()->count())->toBe(3);
+        expect(MedicationRequest::confirmed()->count())->toBe(2);
+    });
+
+    it('calculates appointments correctly', function (): void {
+        $receptor = User::factory()->create(['role' => UserRole::Receptor, 'status' => UserStatus::Approved]);
+        $doctor   = Doctor::factory()->create();
+        $address  = Address::factory()->create(['user_id' => $doctor->user_id]);
+        $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
+        $request  = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+        ]);
+
+        MedicationAppointment::factory()->create([
+            'medication_request_id' => $request->id,
+            'address_id'            => $address->id,
+            'status'                => 'confirmed',
+            'scheduled_date'        => now()->addDays(5),
+        ]);
+
+        $anotherRequest = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => MedicationOffering::factory()->create(['doctor_id' => $doctor->id])->id,
+        ]);
+
+        MedicationAppointment::factory()->create([
+            'medication_request_id' => $anotherRequest->id,
+            'address_id'            => $address->id,
+            'status'                => 'completed',
+        ]);
+
+        expect(MedicationAppointment::confirmed()->count())->toBe(1);
+        expect(MedicationAppointment::completed()->count())->toBe(1);
+    });
+});
+
+describe('Top Doctors and Drugs Queries', function (): void {
+    it('finds doctors with most offerings', function (): void {
+        $doctor1 = Doctor::factory()->create();
+        $doctor2 = Doctor::factory()->create();
+
+        MedicationOffering::factory()->count(5)->create([
+            'doctor_id' => $doctor1->id,
+            'quantity'  => 10,
+        ]);
+
+        MedicationOffering::factory()->count(2)->create([
+            'doctor_id' => $doctor2->id,
+            'quantity'  => 20,
+        ]);
+
+        $topDoctors = Doctor::query()
+            ->whereHas('medicationOfferings')
+            ->withCount(['medicationOfferings as total_offerings'])
+            ->withSum('medicationOfferings', 'quantity')
+            ->orderByDesc('total_offerings')
+            ->get();
+
+        expect($topDoctors)->toHaveCount(2);
+        expect($topDoctors->first()->id)->toBe($doctor1->id);
+        expect($topDoctors->first()->total_offerings)->toBe(5);
+    });
+
+    it('finds drugs with most offerings', function (): void {
+        $doctor = Doctor::factory()->create();
+        $drug1  = Drug::factory()->create(['product_name' => 'Popular Drug']);
+        $drug2  = Drug::factory()->create(['product_name' => 'Less Popular Drug']);
+
+        MedicationOffering::factory()->count(10)->create([
+            'doctor_id' => $doctor->id,
+            'drug_id'   => $drug1->id,
+            'quantity'  => 5,
+        ]);
+
+        MedicationOffering::factory()->count(3)->create([
+            'doctor_id' => $doctor->id,
+            'drug_id'   => $drug2->id,
+            'quantity'  => 20,
+        ]);
+
+        $topDrugs = Drug::query()
+            ->whereHas('medicationOfferings')
+            ->withCount(['medicationOfferings as total_offerings'])
+            ->withSum('medicationOfferings', 'quantity')
+            ->orderByDesc('medication_offerings_sum_quantity')
+            ->get();
+
+        expect($topDrugs)->toHaveCount(2);
+        // Drug2 has more total quantity (3*20=60 vs 10*5=50)
+        expect($topDrugs->first()->id)->toBe($drug2->id);
+    });
+});


### PR DESCRIPTION
## Summary

Implementa dashboard de relatórios e analytics no painel administrativo Filament, permitindo que administradores visualizem métricas do sistema de doações.

### Novos Widgets
- **DonationStatsWidget** - Estatísticas gerais de ofertas (total, disponíveis, concluídas, unidades doadas)
- **RequestStatsWidget** - Estatísticas de solicitações e agendamentos
- **TopDoctorsWidget** - Ranking dos médicos mais ativos
- **TopDrugsWidget** - Ranking dos medicamentos mais doados

### Novos Resources (somente leitura)
- **MedicationOfferingResource** - Visualização de ofertas com badge de disponíveis
- **MedicationRequestResource** - Visualização de solicitações com badge de pendentes
- **MedicationAppointmentResource** - Visualização de agendamentos com badge de próximos

### Página de Relatórios
- Gráficos de tendência (últimos 7 dias)
- Distribuição de status (gráfico de rosca)
- Comparativo mensal (últimos 6 meses)
- Métricas resumidas com taxa de crescimento

## Changes

- 4 widgets (DonationStatsWidget, RequestStatsWidget, TopDoctorsWidget, TopDrugsWidget)
- 3 resources com páginas List e View
- 1 página customizada Reports com Chart.js
- 19 testes cobrindo badges, permissões e cálculos

## Test plan

- [x] Testes unitários passando (473 testes, 1501 assertions)
- [x] PHPStan sem erros
- [x] Pint formatação OK
- [ ] Testar acesso ao painel admin
- [ ] Verificar widgets no dashboard
- [ ] Verificar recursos no menu "Doações"
- [ ] Verificar página de relatórios com gráficos

Closes #69