### PR TITLE
feat(web): implement LGPD data protection for sensitive user data

### DIFF
--- a/web/app/Http/Requests/Auth/ReceptorRegistrationRequest.php
+++ b/web/app/Http/Requests/Auth/ReceptorRegistrationRequest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace App\Http\Requests\Auth;
 
 use App\Models\User;
+use App\Rules\UniqueCpfHash;
 use App\Rules\ValidCPF;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules;
@@ -29,7 +30,7 @@ class ReceptorRegistrationRequest extends FormRequest
         return [
             'name'           => ['required', 'string', 'max:255'],
             'email'          => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
-            'cpf'            => ['required', 'string', new ValidCPF(), 'unique:' . User::class . ',cpf'],
+            'cpf'            => ['required', 'string', new ValidCPF(), new UniqueCpfHash()],
             'phone_number'   => ['required', 'string', 'min:10', 'max:11', 'unique:' . User::class . ',phone_number'],
             'password'       => ['required', 'confirmed', Rules\Password::defaults()],
             'device_name'    => ['required', 'string', 'max:255'],
@@ -64,7 +65,6 @@ class ReceptorRegistrationRequest extends FormRequest
             'email.email'             => 'O e-mail deve ser um endereço de e-mail válido.',
             'email.unique'            => 'Este e-mail já está cadastrado.',
             'cpf.required'            => 'O CPF é obrigatório.',
-            'cpf.unique'              => 'Este CPF já está cadastrado.',
             'phone_number.required'   => 'O telefone é obrigatório.',
             'phone_number.min'        => 'O telefone deve ter pelo menos 10 dígitos.',
             'phone_number.max'        => 'O telefone deve ter no máximo 11 dígitos.',

--- a/web/app/Http/Resources/Api/V1/MedicationRequestResource.php
+++ b/web/app/Http/Resources/Api/V1/MedicationRequestResource.php
@@ -20,6 +20,16 @@ class MedicationRequestResource extends JsonResource
     #[\Override]
     public function toArray(Request $request): array
     {
+        // Only expose full contact details when the request is confirmed
+        // This protects receptor privacy while allowing necessary communication
+        $isConfirmed      = $this->status === 'confirmed';
+        $receptorData     = $this->whenLoaded('receptor');
+        $receptorResource = $receptorData
+            ? ($isConfirmed
+                ? ReceptorResource::make($receptorData)->withContactDetails()
+                : ReceptorResource::make($receptorData))
+            : null;
+
         return [
             'id'                  => $this->id,
             'status'              => $this->status,
@@ -28,7 +38,7 @@ class MedicationRequestResource extends JsonResource
             'medication_offering' => MedicationOfferingSearchResource::make(
                 $this->whenLoaded('medicationOffering')
             ),
-            'receptor' => ReceptorResource::make($this->whenLoaded('receptor')),
+            'receptor' => $receptorResource,
         ];
     }
 }

--- a/web/app/Http/Resources/Api/V1/ReceptorResource.php
+++ b/web/app/Http/Resources/Api/V1/ReceptorResource.php
@@ -10,10 +10,29 @@ use Illuminate\Http\Resources\Json\JsonResource;
 /**
  * Resource for receptor (patient) data in medication request context.
  *
+ * Contact information (email, phone) is only exposed when the request
+ * status allows contact (confirmed status). This protects user privacy
+ * while still allowing necessary communication for deliveries.
+ *
  * @mixin \App\Models\User
  */
 class ReceptorResource extends JsonResource
 {
+    /**
+     * Whether to expose full contact details.
+     */
+    private bool $exposeContactDetails = false;
+
+    /**
+     * Allow contact details to be exposed.
+     */
+    public function withContactDetails(): self
+    {
+        $this->exposeContactDetails = true;
+
+        return $this;
+    }
+
     /**
      * Transform the resource into an array.
      *
@@ -22,11 +41,74 @@ class ReceptorResource extends JsonResource
     #[\Override]
     public function toArray(Request $request): array
     {
-        return [
-            'id'           => $this->id,
-            'name'         => $this->name,
-            'email'        => $this->email,
-            'phone_number' => $this->phone_number,
+        $data = [
+            'id'   => $this->id,
+            'name' => $this->name,
         ];
+
+        // Only expose full contact info when explicitly allowed
+        // This should be used when the medication request is confirmed
+        if ($this->exposeContactDetails) {
+            $data['email']        = $this->email;
+            $data['phone_number'] = $this->phone_number;
+        } else {
+            // Masked versions for privacy
+            $data['email']        = $this->maskEmail($this->email);
+            $data['phone_number'] = $this->maskPhone($this->phone_number);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Mask email address for privacy.
+     * Example: john.doe@example.com -> j*****e@e****e.com
+     */
+    private function maskEmail(?string $email): ?string
+    {
+        if ($email === null || $email === '') {
+            return null;
+        }
+
+        $parts = explode('@', $email);
+
+        if (count($parts) !== 2) {
+            return '***@***.***';
+        }
+
+        [$local, $domain] = $parts;
+
+        $maskedLocal = mb_strlen($local) > 2
+            ? mb_substr($local, 0, 1) . str_repeat('*', mb_strlen($local) - 2) . mb_substr($local, -1)
+            : str_repeat('*', mb_strlen($local));
+
+        $domainParts  = explode('.', $domain);
+        $maskedDomain = array_map(fn ($part): string => mb_strlen((string) $part) > 2
+            ? mb_substr((string) $part, 0, 1) . str_repeat('*', mb_strlen((string) $part) - 2) . mb_substr((string) $part, -1)
+            : str_repeat('*', mb_strlen((string) $part)), $domainParts);
+
+        return $maskedLocal . '@' . implode('.', $maskedDomain);
+    }
+
+    /**
+     * Mask phone number for privacy.
+     * Example: 11987654321 -> (11) *****-4321
+     */
+    private function maskPhone(?string $phone): ?string
+    {
+        if ($phone === null || $phone === '') {
+            return null;
+        }
+
+        $digits = preg_replace('/\D/', '', $phone) ?? '';
+
+        if (mb_strlen($digits) < 4) {
+            return str_repeat('*', mb_strlen($digits));
+        }
+
+        $lastFour = mb_substr($digits, -4);
+        $areaCode = mb_strlen($digits) >= 10 ? mb_substr($digits, 0, 2) : '**';
+
+        return "({$areaCode}) *****-{$lastFour}";
     }
 }

--- a/web/app/Models/User.php
+++ b/web/app/Models/User.php
@@ -34,6 +34,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'name',
         'email',
         'cpf',
+        'cpf_hash',
         'role',
         'status',
         'status_changed_at',
@@ -43,6 +44,22 @@ class User extends Authenticatable implements MustVerifyEmail
         'terms_accepted',
         'terms_accepted_at',
     ];
+
+    /**
+     * Boot the model.
+     */
+    #[\Override]
+    protected static function booted(): void
+    {
+        static::saving(function (User $user): void {
+            // Auto-generate cpf_hash when cpf changes
+            if ($user->isDirty('cpf') && $user->cpf !== null) {
+                $user->cpf_hash = hash('sha256', $user->cpf);
+            } elseif ($user->cpf === null) {
+                $user->cpf_hash = null;
+            }
+        });
+    }
 
     protected $hidden = [
         'password',
@@ -61,6 +78,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'terms_accepted_at' => 'datetime',
             'status_changed_at' => 'datetime',
             'password'          => 'hashed',
+            'cpf'               => 'encrypted',
             'role'              => UserRole::class,
             'status'            => UserStatus::class,
         ];
@@ -168,11 +186,14 @@ class User extends Authenticatable implements MustVerifyEmail
 
     /**
      * Configure activity logging options.
+     *
+     * Note: CPF and phone_number are NOT logged for LGPD compliance.
+     * These are sensitive personal data that should not be stored in audit logs.
      */
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['name', 'email', 'phone_number', 'cpf', 'role', 'status'])
+            ->logOnly(['name', 'email', 'role', 'status'])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs()
             ->setDescriptionForEvent(fn (string $eventName): string => match ($eventName) {

--- a/web/app/Rules/UniqueCpfHash.php
+++ b/web/app/Rules/UniqueCpfHash.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Rules;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Validates that a CPF is unique by checking its hash.
+ *
+ * Since CPF is encrypted, we can't use a normal unique rule.
+ * This rule hashes the CPF and checks against the cpf_hash column.
+ */
+class UniqueCpfHash implements ValidationRule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @param  int|null  $ignoreId  User ID to ignore (for updates)
+     */
+    public function __construct(
+        private readonly ?int $ignoreId = null
+    ) {
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $hash  = hash('sha256', $value);
+        $query = User::where('cpf_hash', $hash);
+
+        if ($this->ignoreId !== null) {
+            $query->where('id', '!=', $this->ignoreId);
+        }
+
+        if ($query->exists()) {
+            $fail('Este CPF já está cadastrado.');
+        }
+    }
+}

--- a/web/database/migrations/2026_01_27_144441_encrypt_cpf_column_in_users_table.php
+++ b/web/database/migrations/2026_01_27_144441_encrypt_cpf_column_in_users_table.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Migration to encrypt CPF data for LGPD compliance.
+ *
+ * This migration:
+ * 1. Changes CPF column to TEXT to accommodate encrypted data
+ * 2. Encrypts existing CPF values
+ * 3. Removes unique constraint (encrypted values can't be indexed)
+ *
+ * IMPORTANT: After this migration, CPF searches must decrypt all values.
+ * Consider creating a separate hashed_cpf column for lookups if needed.
+ */
+return new class () extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Step 1: Remove unique constraint and change column type
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropUnique(['cpf']);
+            $table->text('cpf')->nullable()->change();
+        });
+
+        // Step 2: Encrypt existing CPF values
+        DB::table('users')
+            ->whereNotNull('cpf')
+            ->orderBy('id')
+            ->chunk(100, function ($users): void {
+                foreach ($users as $user) {
+                    // Only encrypt if not already encrypted (starts with eyJ which is base64 JSON)
+                    if ($user->cpf && ! str_starts_with((string) $user->cpf, 'eyJ')) {
+                        DB::table('users')
+                            ->where('id', $user->id)
+                            ->update(['cpf' => Crypt::encryptString($user->cpf)]);
+                    }
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Step 1: Decrypt existing CPF values
+        DB::table('users')
+            ->whereNotNull('cpf')
+            ->orderBy('id')
+            ->chunk(100, function ($users): void {
+                foreach ($users as $user) {
+                    if ($user->cpf && str_starts_with((string) $user->cpf, 'eyJ')) {
+                        try {
+                            $decrypted = Crypt::decryptString($user->cpf);
+                            DB::table('users')
+                                ->where('id', $user->id)
+                                ->update(['cpf' => $decrypted]);
+                        } catch (Illuminate\Contracts\Encryption\DecryptException) {
+                            // If decryption fails, leave as is
+                        }
+                    }
+                }
+            });
+
+        // Step 2: Change column back to varchar and add unique constraint
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('cpf', 11)->nullable()->change();
+            $table->unique('cpf');
+        });
+    }
+};

--- a/web/database/migrations/2026_01_27_144513_add_cpf_hash_to_users_table.php
+++ b/web/database/migrations/2026_01_27_144513_add_cpf_hash_to_users_table.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add cpf_hash column for unique validation and lookups.
+ *
+ * Since CPF is now encrypted, we need a deterministic hash for:
+ * 1. Unique constraint validation
+ * 2. Fast lookups by CPF
+ *
+ * The hash is one-way (SHA-256) so the original CPF cannot be recovered from it.
+ */
+return new class () extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('cpf_hash', 64)->nullable()->unique()->after('cpf');
+        });
+
+        // Generate hashes for existing CPFs
+        DB::table('users')
+            ->whereNotNull('cpf')
+            ->orderBy('id')
+            ->chunk(100, function ($users): void {
+                foreach ($users as $user) {
+                    $cpf = $user->cpf;
+
+                    // If encrypted, decrypt first
+                    if ($cpf && str_starts_with($cpf, 'eyJ')) {
+                        try {
+                            $cpf = Crypt::decryptString($cpf);
+                        } catch (Illuminate\Contracts\Encryption\DecryptException) {
+                            continue;
+                        }
+                    }
+
+                    if ($cpf) {
+                        DB::table('users')
+                            ->where('id', $user->id)
+                            ->update(['cpf_hash' => hash('sha256', $cpf)]);
+                    }
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('cpf_hash');
+        });
+    }
+};

--- a/web/tests/Feature/Auth/RegisterReceptorTest.php
+++ b/web/tests/Feature/Auth/RegisterReceptorTest.php
@@ -42,10 +42,11 @@ describe('Receptor Registration - Success Scenarios', function (): void {
         ]);
 
         // Verify user was created in database
+        // Note: CPF is now encrypted, so we check via cpf_hash
         assertDatabaseHas('users', [
             'name'         => 'Maria Silva',
             'email'        => 'maria@example.com',
-            'cpf'          => '52998224725', // Stored without mask
+            'cpf_hash'     => hash('sha256', '52998224725'), // CPF hash for lookup
             'phone_number' => '11987654321',
             'role'         => 'receptor',
         ]);
@@ -370,9 +371,14 @@ describe('Receptor Registration - Security Tests', function (): void {
             'terms_accepted'        => true,
         ])->assertCreated();
 
+        // CPF is encrypted but hash is deterministic, verifying mask was removed
         assertDatabaseHas('users', [
-            'cpf' => '52998224725', // Stored without mask
+            'cpf_hash' => hash('sha256', '52998224725'), // Hash of CPF without mask
         ]);
+
+        // Also verify via model that decrypted CPF is correct
+        $user = User::whereEmail('security@example.com')->first();
+        expect($user->cpf)->toBe('52998224725');
     });
 
     it('should sanitize phone number input (remove mask)', function (): void {

--- a/web/tests/Feature/Security/LgpdDataProtectionTest.php
+++ b/web/tests/Feature/Security/LgpdDataProtectionTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\MedicationOffering;
+use App\Models\MedicationRequest;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+use function Pest\Laravel\actingAs;
+
+/*
+|--------------------------------------------------------------------------
+| LGPD Data Protection Tests
+|--------------------------------------------------------------------------
+|
+| Tests to verify that sensitive personal data is properly protected
+| according to LGPD (Lei Geral de Proteção de Dados) requirements.
+|
+*/
+
+describe('CPF Encryption', function (): void {
+    it('should store CPF encrypted in database', function (): void {
+        $user = User::factory()->receptor()->create([
+            'cpf' => '52998224725',
+        ]);
+
+        // Get raw value from database
+        $rawCpf = DB::table('users')->where('id', $user->id)->value('cpf');
+
+        // CPF should be encrypted (not the plain value)
+        expect($rawCpf)->not->toBe('52998224725');
+        expect($rawCpf)->toStartWith('eyJ'); // Laravel encryption starts with base64-encoded JSON
+    });
+
+    it('should decrypt CPF correctly when accessed via model', function (): void {
+        $user = User::factory()->receptor()->create([
+            'cpf' => '52998224725',
+        ]);
+
+        // Fresh load from database
+        $loadedUser = User::find($user->id);
+
+        // Model should decrypt automatically
+        expect($loadedUser->cpf)->toBe('52998224725');
+    });
+
+    it('should generate cpf_hash for lookups', function (): void {
+        $user = User::factory()->receptor()->create([
+            'cpf' => '52998224725',
+        ]);
+
+        // Check that hash was generated
+        expect($user->cpf_hash)->toBe(hash('sha256', '52998224725'));
+    });
+
+    it('should allow finding user by cpf_hash', function (): void {
+        $user = User::factory()->receptor()->create([
+            'cpf' => '52998224725',
+        ]);
+
+        $found = User::where('cpf_hash', hash('sha256', '52998224725'))->first();
+
+        expect($found)->not->toBeNull();
+        expect($found->id)->toBe($user->id);
+    });
+});
+
+describe('Activity Log Privacy', function (): void {
+    it('should NOT log CPF in activity log', function (): void {
+        $user = User::factory()->receptor()->create([
+            'cpf' => '52998224725',
+        ]);
+
+        $user->update(['cpf' => '14538220620']);
+
+        // Check activity log
+        $activity = DB::table('activity_log')
+            ->where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->latest()
+            ->first();
+
+        // If there's an activity log, CPF should not be in properties
+        if ($activity && $activity->properties) {
+            $properties = json_decode((string) $activity->properties, true);
+            expect($properties)->not->toHaveKey('old.cpf');
+            expect($properties)->not->toHaveKey('attributes.cpf');
+
+            if (isset($properties['old'])) {
+                expect($properties['old'])->not->toHaveKey('cpf');
+            }
+
+            if (isset($properties['attributes'])) {
+                expect($properties['attributes'])->not->toHaveKey('cpf');
+            }
+        }
+    });
+
+    it('should NOT log phone_number in activity log', function (): void {
+        $user = User::factory()->receptor()->create([
+            'phone_number' => '11987654321',
+        ]);
+
+        $user->update(['phone_number' => '21987654321']);
+
+        // Check activity log
+        $activity = DB::table('activity_log')
+            ->where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->latest()
+            ->first();
+
+        // If there's an activity log, phone_number should not be in properties
+        if ($activity && $activity->properties) {
+            $properties = json_decode((string) $activity->properties, true);
+
+            if (isset($properties['old'])) {
+                expect($properties['old'])->not->toHaveKey('phone_number');
+            }
+
+            if (isset($properties['attributes'])) {
+                expect($properties['attributes'])->not->toHaveKey('phone_number');
+            }
+        }
+    });
+});
+
+describe('API Data Masking', function (): void {
+    it('should mask receptor email in pending medication requests', function (): void {
+        $receptor = User::factory()->receptor()->create([
+            'email' => 'johndoe@example.com',
+        ]);
+
+        $doctor = User::factory()->doctor()->create();
+
+        $offering = MedicationOffering::factory()->create([
+            'doctor_id' => $doctor->doctor->id,
+            'status'    => 'available',
+        ]);
+
+        $request = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'pending',
+        ]);
+
+        $response = actingAs($doctor)
+            ->getJson(route('api.v1.medication-requests.received'));
+
+        $response->assertOk();
+
+        $data = $response->json('data.0.receptor');
+
+        // Email should be masked
+        expect($data['email'])->not->toBe('johndoe@example.com');
+        expect($data['email'])->toContain('*');
+    });
+
+    it('should mask receptor phone in pending medication requests', function (): void {
+        $receptor = User::factory()->receptor()->create([
+            'phone_number' => '11987654321',
+        ]);
+
+        $doctor = User::factory()->doctor()->create();
+
+        $offering = MedicationOffering::factory()->create([
+            'doctor_id' => $doctor->doctor->id,
+            'status'    => 'available',
+        ]);
+
+        $request = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'pending',
+        ]);
+
+        $response = actingAs($doctor)
+            ->getJson(route('api.v1.medication-requests.received'));
+
+        $response->assertOk();
+
+        $data = $response->json('data.0.receptor');
+
+        // Phone should be masked
+        expect($data['phone_number'])->not->toBe('11987654321');
+        expect($data['phone_number'])->toContain('*');
+    });
+
+    it('should expose full receptor contact info in confirmed medication requests', function (): void {
+        $receptor = User::factory()->receptor()->create([
+            'email'        => 'johndoe@example.com',
+            'phone_number' => '11987654321',
+        ]);
+
+        $doctor = User::factory()->doctor()->create();
+
+        $offering = MedicationOffering::factory()->create([
+            'doctor_id' => $doctor->doctor->id,
+            'status'    => 'reserved',
+        ]);
+
+        $request = MedicationRequest::factory()->create([
+            'receptor_id'            => $receptor->id,
+            'medication_offering_id' => $offering->id,
+            'status'                 => 'confirmed',
+        ]);
+
+        $response = actingAs($doctor)
+            ->getJson(route('api.v1.medication-requests.received'));
+
+        $response->assertOk();
+
+        $data = $response->json('data.0.receptor');
+
+        // Full contact info should be exposed for confirmed requests
+        expect($data['email'])->toBe('johndoe@example.com');
+        expect($data['phone_number'])->toBe('11987654321');
+    });
+});
+
+describe('CPF Unique Validation with Encryption', function (): void {
+    it('should prevent duplicate CPF registration', function (): void {
+        User::factory()->receptor()->create([
+            'cpf' => '52998224725',
+        ]);
+
+        // Try to create another user with same CPF
+        $response = \Pest\Laravel\postJson(route('receptor.register'), [
+            'name'                  => 'Duplicate User',
+            'email'                 => 'duplicate@example.com',
+            'cpf'                   => '529.982.247-25', // Same CPF with mask
+            'phone_number'          => '(21) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['cpf']);
+    });
+});


### PR DESCRIPTION
## Descrição

Implementação de proteção de dados pessoais para conformidade com a LGPD (Lei Geral de Proteção de Dados).

## O que foi implementado

### Criptografia de CPF
- CPF agora é criptografado em repouso usando Laravel's `encrypted` cast
- Coluna `cpf_hash` adicionada para permitir validação de unicidade e buscas
- Nova regra de validação `UniqueCpfHash` para verificar CPF duplicado
- Auto-geração do hash no model User ao salvar

### Proteção de Activity Logs
- CPF e telefone removidos da lista de campos logados no User
- Dados sensíveis não são mais armazenados em activity logs

### Mascaramento de Dados nas APIs
- `ReceptorResource` agora mascara email e telefone por padrão
- Email: `j*****e@e****e.com`
- Telefone: `(11) *****-4321`
- Contato completo só é exposto quando a solicitação está confirmada

## Arquivos modificados

**Backend:**
- `app/Models/User.php` - Cast encrypted, cpf_hash auto-generation
- `app/Rules/UniqueCpfHash.php` - Nova regra de validação
- `app/Http/Requests/Auth/ReceptorRegistrationRequest.php` - Usa nova regra
- `app/Http/Resources/Api/V1/ReceptorResource.php` - Mascaramento de dados
- `app/Http/Resources/Api/V1/MedicationRequestResource.php` - Exposição condicional
- Migrations para criptografar dados existentes e adicionar cpf_hash

## Testes

- 10 novos testes específicos para proteção de dados LGPD
- 483 testes passando (1524 assertions)
- PHPStan level 6 sem erros

## Test Plan

- [x] CPF é criptografado no banco de dados
- [x] CPF hash é gerado automaticamente
- [x] Validação de CPF único funciona com criptografia
- [x] Activity logs não contêm CPF ou telefone
- [x] Email e telefone são mascarados em solicitações pendentes
- [x] Contato completo é exposto em solicitações confirmadas
- [x] Todos os testes existentes continuam passando

Closes #72