### PR TITLE
feat(auth): implement token expiration with refresh token system

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -15,12 +15,19 @@ Production:  https://api.doafarma.com/api
 
 ## Authentication
 
-DoaFarma uses Laravel Sanctum for token-based authentication.
+DoaFarma uses Laravel Sanctum for token-based authentication with refresh tokens.
 
-### Getting a Token
+### Token Types
+
+| Token | Expiration | Ability | Usage |
+|-------|-----------|---------|-------|
+| Access Token | 1 hour | `access` | API requests |
+| Refresh Token | 30 days | `refresh` | Get new access token |
+
+### Login (Getting Tokens)
 
 ```http
-POST /login
+POST /v1/auth/login
 Content-Type: application/json
 
 {
@@ -33,30 +40,74 @@ Content-Type: application/json
 **Response (200):**
 ```json
 {
-    "token": "1|abc123...",
-    "user": {
-        "id": 1,
-        "name": "Dr. João Silva",
-        "email": "doctor@example.com",
-        "role": "doctor",
-        "status": "approved"
-    }
+    "data": {
+        "user": {
+            "id": 1,
+            "name": "Dr. João Silva",
+            "email": "doctor@example.com",
+            "role": "doctor",
+            "status": "approved"
+        },
+        "access_token": "1|abc123...",
+        "refresh_token": "2|xyz789...",
+        "expires_in": 3600,
+        "refresh_expires_in": 2592000
+    },
+    "message": "Login realizado com sucesso"
 }
 ```
 
-### Using the Token
+### Using the Access Token
 
-Include the token in the `Authorization` header:
+Include the access token in the `Authorization` header:
 
 ```http
 Authorization: Bearer 1|abc123...
 ```
 
+### Refreshing the Access Token
+
+When the access token expires, use the refresh token to get a new one:
+
+```http
+POST /v1/auth/refresh
+Authorization: Bearer 2|xyz789...
+```
+
+**Response (200):**
+```json
+{
+    "data": {
+        "access_token": "3|newtoken...",
+        "expires_in": 3600
+    },
+    "message": "Token renovado com sucesso"
+}
+```
+
+### Logout
+
+Revokes all tokens for the current device:
+
+```http
+POST /v1/auth/logout
+Authorization: Bearer 1|abc123...
+```
+
+**Response (200):**
+```json
+{
+    "message": "Logout realizado com sucesso"
+}
+```
+
 ### Token Lifecycle
 
-- Tokens do not expire automatically
-- Token is invalidated on logout
-- Multiple tokens per user allowed (multi-device)
+- **Access token expires after 1 hour** - use refresh token to renew
+- **Refresh token expires after 30 days** - user must login again
+- Logout revokes all tokens for the device (access + refresh)
+- Multiple devices allowed (each device has its own token pair)
+- Rate limiting: 5 login attempts per minute per email+IP
 
 ---
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -217,6 +217,36 @@ Addresses are stored as text. Geocoding, map integration, or proximity search ar
 
 ---
 
+### D14: Refresh Token Pattern for Authentication
+
+**Decision:** Implement industry-standard refresh token pattern instead of single long-lived token.
+
+**Rationale:**
+- Access tokens expire in 1 hour (limits exposure if compromised)
+- Refresh tokens expire in 30 days (good UX without re-login)
+- Sanctum abilities (`access`, `refresh`) prevent token misuse
+- Device-specific tokens allow selective logout
+- Follows OAuth 2.0 best practices
+
+**Implementation:**
+- `CreateTokenPairAction`: Creates access + refresh token pair
+- `RefreshTokenAction`: Issues new access token using valid refresh token
+- `LogoutAction`: Revokes all tokens for specific device
+- Middleware `abilities:refresh` protects refresh endpoint
+
+**Security measures:**
+- Rate limiting on login (5 attempts/minute per email+IP)
+- User status validation on refresh (blocks pending/rejected users)
+- Sanctum Guard auto-validates token expiration
+
+**Future improvements identified by code review (see Future Considerations):**
+- Security logging for auth events
+- Rate limiting on refresh endpoint
+- Refresh token rotation
+- Token theft detection
+
+---
+
 ## Future Considerations
 
 Items explicitly out of scope but documented for awareness:
@@ -227,5 +257,13 @@ Items explicitly out of scope but documented for awareness:
 4. **Analytics dashboard** - Usage statistics
 5. **External CRM validation** - API integration with medical councils
 6. **Multi-language support** - Internationalization
+
+### Authentication Improvements (from D14 code review)
+
+7. **Security logging** - Log login attempts, token refreshes, logouts, and failed auth for audit trail (OWASP A09:2021)
+8. **Rate limiting on refresh** - Add throttle middleware to `/auth/refresh` endpoint to prevent token generation abuse
+9. **Refresh token rotation** - Issue new refresh token on each refresh, invalidate the old one (increases security)
+10. **Token theft detection** - Detect when a rotated refresh token is reused (indicates possible compromise)
+11. **Device name sanitization** - Add regex validation to prevent special characters in device names
 
 These may be added post-TCC if the project continues.

--- a/docs/postman/DoaFarma-Auth.postman_collection.json
+++ b/docs/postman/DoaFarma-Auth.postman_collection.json
@@ -1,0 +1,353 @@
+{
+  "info": {
+    "name": "DoaFarma - Auth",
+    "_postman_id": "doafarma-auth-collection",
+    "description": "Collection para testar autenticação com refresh tokens",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8000/api",
+      "type": "string"
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "refresh_token",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "1. Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('access_token', jsonData.data.access_token);",
+                  "    pm.collectionVariables.set('refresh_token', jsonData.data.refresh_token);",
+                  "    ",
+                  "    pm.test('Login successful', function () {",
+                  "        pm.expect(jsonData.data).to.have.property('access_token');",
+                  "        pm.expect(jsonData.data).to.have.property('refresh_token');",
+                  "        pm.expect(jsonData.data.expires_in).to.eql(3600);",
+                  "    });",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"teste@teste.com\",\n    \"password\": \"password123\",\n    \"device_name\": \"postman-test\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "login"]
+            },
+            "description": "Faz login e salva automaticamente access_token e refresh_token nas variáveis da collection."
+          },
+          "response": []
+        },
+        {
+          "name": "2. Get Current User (com Access Token)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Access token funciona', function () {",
+                  "    pm.expect(pm.response.code).to.eql(200);",
+                  "});",
+                  "",
+                  "pm.test('Retorna dados do usuário', function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('email');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            },
+            "description": "Usa o access_token para acessar rota protegida."
+          },
+          "response": []
+        },
+        {
+          "name": "3. Refresh Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('access_token', jsonData.data.access_token);",
+                  "    ",
+                  "    pm.test('Refresh successful', function () {",
+                  "        pm.expect(jsonData.data).to.have.property('access_token');",
+                  "        pm.expect(jsonData.data.expires_in).to.eql(3600);",
+                  "    });",
+                  "    ",
+                  "    pm.test('Novo access token é diferente', function () {",
+                  "        pm.expect(jsonData.data.access_token).to.not.be.empty;",
+                  "    });",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{refresh_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/auth/refresh",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "refresh"]
+            },
+            "description": "Usa o refresh_token para obter novo access_token. O novo token é salvo automaticamente."
+          },
+          "response": []
+        },
+        {
+          "name": "4. Logout",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Logout successful', function () {",
+                  "    pm.expect(pm.response.code).to.eql(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    pm.collectionVariables.set('access_token', '');",
+                  "    pm.collectionVariables.set('refresh_token', '');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/auth/logout",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "logout"]
+            },
+            "description": "Revoga todos os tokens do device. Limpa as variáveis da collection."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Error Cases",
+      "item": [
+        {
+          "name": "❌ Refresh token em rota normal (deve falhar 403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Refresh token não funciona em rota normal', function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([401, 403]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{refresh_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            },
+            "description": "Tenta usar refresh_token em rota que exige access. Deve falhar."
+          },
+          "response": []
+        },
+        {
+          "name": "❌ Access token para refresh (deve falhar 403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Access token não funciona para refresh', function () {",
+                  "    pm.expect(pm.response.code).to.eql(403);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/auth/refresh",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "refresh"]
+            },
+            "description": "Tenta usar access_token para refresh. Deve falhar com 403."
+          },
+          "response": []
+        },
+        {
+          "name": "❌ Token inválido (deve falhar 401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Token inválido retorna 401', function () {",
+                  "    pm.expect(pm.response.code).to.eql(401);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer token-invalido-qualquer"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            },
+            "description": "Usa token inválido. Deve retornar 401."
+          },
+          "response": []
+        },
+        {
+          "name": "❌ Sem token (deve falhar 401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Sem token retorna 401', function () {",
+                  "    pm.expect(pm.response.code).to.eql(401);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            },
+            "description": "Requisição sem token. Deve retornar 401."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/postman/DoaFarma-Complete.postman_collection.json
+++ b/docs/postman/DoaFarma-Complete.postman_collection.json
@@ -1,0 +1,863 @@
+{
+  "info": {
+    "name": "DoaFarma - Complete API",
+    "_postman_id": "doafarma-complete-api",
+    "description": "Collection completa da API DoaFarma.\n\n## Usuários de teste (seeders)\n- **Doctor**: doctor@example.com / password\n- **Receptor**: receptor@example.com / password\n\n## Fluxo de autenticação\n1. Execute 'Login (Doctor)' ou 'Login (Receptor)'\n2. Os tokens são salvos automaticamente nas variáveis\n3. Use as outras requisições normalmente",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8000/api",
+      "type": "string"
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "refresh_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "user_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "doctor_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "offering_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "request_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "appointment_id",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{access_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login (Doctor)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('access_token', jsonData.data.access_token);",
+                  "    pm.collectionVariables.set('refresh_token', jsonData.data.refresh_token);",
+                  "    pm.collectionVariables.set('user_id', jsonData.data.user.id);",
+                  "    if (jsonData.data.user.doctor) {",
+                  "        pm.collectionVariables.set('doctor_id', jsonData.data.user.doctor.id);",
+                  "    }",
+                  "    pm.test('Login successful', () => pm.expect(jsonData.data.access_token).to.be.a('string'));",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"doctor@example.com\",\n    \"password\": \"password\",\n    \"device_name\": \"postman\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "login"]
+            }
+          }
+        },
+        {
+          "name": "Login (Receptor)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('access_token', jsonData.data.access_token);",
+                  "    pm.collectionVariables.set('refresh_token', jsonData.data.refresh_token);",
+                  "    pm.collectionVariables.set('user_id', jsonData.data.user.id);",
+                  "    pm.test('Login successful', () => pm.expect(jsonData.data.access_token).to.be.a('string'));",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"receptor@example.com\",\n    \"password\": \"password\",\n    \"device_name\": \"postman\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "login"]
+            }
+          }
+        },
+        {
+          "name": "Refresh Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('access_token', jsonData.data.access_token);",
+                  "    pm.test('Refresh successful', () => pm.expect(jsonData.data.access_token).to.be.a('string'));",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{refresh_token}}", "type": "string" }]
+            },
+            "method": "POST",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/auth/refresh",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "refresh"]
+            }
+          }
+        },
+        {
+          "name": "Logout",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    pm.collectionVariables.set('access_token', '');",
+                  "    pm.collectionVariables.set('refresh_token', '');",
+                  "    pm.test('Logout successful', () => pm.response.to.have.status(200));",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/auth/logout",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "logout"]
+            }
+          }
+        },
+        {
+          "name": "Get Current User",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Registration",
+      "item": [
+        {
+          "name": "Register Doctor",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Dr. Novo Médico\",\n    \"email\": \"novo.medico@example.com\",\n    \"password\": \"password123\",\n    \"password_confirmation\": \"password123\",\n    \"cpf\": \"529.982.247-25\",\n    \"phone_number\": \"(11) 99999-9999\",\n    \"crm\": \"123456\",\n    \"crm_uf\": \"SP\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/register/doctor",
+              "host": ["{{base_url}}"],
+              "path": ["register", "doctor"]
+            }
+          }
+        },
+        {
+          "name": "Register Receptor",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Novo Receptor\",\n    \"email\": \"novo.receptor@example.com\",\n    \"password\": \"password123\",\n    \"password_confirmation\": \"password123\",\n    \"cpf\": \"987.654.321-00\",\n    \"phone_number\": \"(11) 88888-8888\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/register/receptor",
+              "host": ["{{base_url}}"],
+              "path": ["register", "receptor"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Drugs",
+      "item": [
+        {
+          "name": "List Drugs",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/drugs?page=1&per_page=15",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "drugs"],
+              "query": [
+                { "key": "page", "value": "1" },
+                { "key": "per_page", "value": "15" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Search Drugs",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/drugs/search?q=dipirona",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "drugs", "search"],
+              "query": [
+                { "key": "q", "value": "dipirona" }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Medication Offerings",
+      "item": [
+        {
+          "name": "List Offerings",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-offerings?page=1",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-offerings"],
+              "query": [
+                { "key": "page", "value": "1" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Search Offerings",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-offerings/search?q=&city=&state=",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-offerings", "search"],
+              "query": [
+                { "key": "q", "value": "", "description": "Nome do medicamento" },
+                { "key": "city", "value": "", "description": "Cidade" },
+                { "key": "state", "value": "", "description": "Estado (UF)" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Offering",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('offering_id', jsonData.data.id);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-offerings/{{offering_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-offerings", "{{offering_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Create Offering (Doctor only)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('offering_id', jsonData.data.id);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"drug_id\": 1,\n    \"quantity\": 10,\n    \"expiration_date\": \"2025-12-31\",\n    \"notes\": \"Medicamento em bom estado\",\n    \"city\": \"São Paulo\",\n    \"state\": \"SP\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/medication-offerings",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-offerings"]
+            }
+          }
+        },
+        {
+          "name": "Update Offering (Doctor only)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"quantity\": 5,\n    \"notes\": \"Quantidade atualizada\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/medication-offerings/{{offering_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-offerings", "{{offering_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Delete Offering (Doctor only)",
+          "request": {
+            "method": "DELETE",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-offerings/{{offering_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-offerings", "{{offering_id}}"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Medication Requests",
+      "item": [
+        {
+          "name": "List My Requests",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-requests",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-requests"]
+            }
+          }
+        },
+        {
+          "name": "List Received Requests (Doctor)",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-requests/received",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-requests", "received"]
+            }
+          }
+        },
+        {
+          "name": "Create Request (Receptor only)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('request_id', jsonData.data.id);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"medication_offering_id\": {{offering_id}}\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/medication-requests",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-requests"]
+            }
+          }
+        },
+        {
+          "name": "Confirm Request (Doctor only)",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-requests/{{request_id}}/confirm",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-requests", "{{request_id}}", "confirm"]
+            }
+          }
+        },
+        {
+          "name": "Reject Request (Doctor only)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"rejection_reason\": \"Medicamento já foi reservado para outro paciente\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/medication-requests/{{request_id}}/reject",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-requests", "{{request_id}}", "reject"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Medication Appointments",
+      "item": [
+        {
+          "name": "List My Appointments",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments"]
+            }
+          }
+        },
+        {
+          "name": "List Received Appointments (Doctor)",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/received",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "received"]
+            }
+          }
+        },
+        {
+          "name": "My History (Receptor)",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/history",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "history"]
+            }
+          }
+        },
+        {
+          "name": "Doctor History",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/doctor-history",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "doctor-history"]
+            }
+          }
+        },
+        {
+          "name": "Create Appointment (Receptor only)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('appointment_id', jsonData.data.id);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"medication_request_id\": {{request_id}},\n    \"proposed_datetime\": \"2025-02-15 14:00:00\",\n    \"location\": \"Consultório - Av. Paulista, 1000\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments"]
+            }
+          }
+        },
+        {
+          "name": "Accept Appointment (Doctor)",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/{{appointment_id}}/accept",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "{{appointment_id}}", "accept"]
+            }
+          }
+        },
+        {
+          "name": "Counter-Propose (Doctor)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"proposed_datetime\": \"2025-02-16 10:00:00\",\n    \"location\": \"Novo local - Rua Augusta, 500\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/{{appointment_id}}/counter-propose",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "{{appointment_id}}", "counter-propose"]
+            }
+          }
+        },
+        {
+          "name": "Confirm Delivery (Receptor)",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/{{appointment_id}}/confirm-delivery-receptor",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "{{appointment_id}}", "confirm-delivery-receptor"]
+            }
+          }
+        },
+        {
+          "name": "Confirm Delivery (Doctor)",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/medication-appointments/{{appointment_id}}/confirm-delivery-doctor",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "medication-appointments", "{{appointment_id}}", "confirm-delivery-doctor"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Doctor Ratings",
+      "item": [
+        {
+          "name": "My Ratings (Doctor)",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/doctor-ratings/my-ratings",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "doctor-ratings", "my-ratings"]
+            }
+          }
+        },
+        {
+          "name": "List Doctor Ratings",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/doctor-ratings/doctor/{{doctor_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "doctor-ratings", "doctor", "{{doctor_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Get Rating by Appointment",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/doctor-ratings/appointment/{{appointment_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "doctor-ratings", "appointment", "{{appointment_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Create Rating (Receptor only)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"rating\": 5,\n    \"comment\": \"Excelente atendimento, muito atencioso!\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/doctor-ratings/{{appointment_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "doctor-ratings", "{{appointment_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Update Rating",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"rating\": 4,\n    \"comment\": \"Bom atendimento\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/doctor-ratings/1",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "doctor-ratings", "1"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Push Tokens",
+      "item": [
+        {
+          "name": "Register Push Token",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"token\": \"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/push-tokens",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "push-tokens"]
+            }
+          }
+        },
+        {
+          "name": "Delete Push Token",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Accept", "value": "application/json" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"token\": \"ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/push-tokens",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "push-tokens"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Error Cases",
+      "item": [
+        {
+          "name": "❌ Refresh token em rota normal (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Refresh token bloqueado em rota normal', () => {",
+                  "    pm.expect(pm.response.code).to.eql(403);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{refresh_token}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            }
+          }
+        },
+        {
+          "name": "❌ Access token para refresh (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Access token bloqueado no refresh', () => {",
+                  "    pm.expect(pm.response.code).to.eql(403);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/v1/auth/refresh",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "auth", "refresh"]
+            }
+          }
+        },
+        {
+          "name": "❌ Sem token (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Requisição sem token retorna 401', () => {",
+                  "    pm.expect(pm.response.code).to.eql(401);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "header": [{ "key": "Accept", "value": "application/json" }],
+            "url": {
+              "raw": "{{base_url}}/user",
+              "host": ["{{base_url}}"],
+              "path": ["user"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/web/app/Actions/Auth/CreateTokenPairAction.php
+++ b/web/app/Actions/Auth/CreateTokenPairAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\Auth;
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+class CreateTokenPairAction
+{
+    public const ACCESS_EXPIRATION_HOURS = 1;
+
+    public const REFRESH_EXPIRATION_DAYS = 30;
+
+    /**
+     * Create a pair of tokens (access + refresh) for the user.
+     *
+     * @return array{access_token: string, refresh_token: string, expires_in: int, refresh_expires_in: int}
+     */
+    public function execute(User $user, string $deviceName): array
+    {
+        $now = CarbonImmutable::now();
+
+        $accessToken = $user->createToken(
+            name: "{$deviceName}:access",
+            abilities: ['access'],
+            expiresAt: $now->addHours(self::ACCESS_EXPIRATION_HOURS)
+        );
+
+        $refreshToken = $user->createToken(
+            name: "{$deviceName}:refresh",
+            abilities: ['refresh'],
+            expiresAt: $now->addDays(self::REFRESH_EXPIRATION_DAYS)
+        );
+
+        return [
+            'access_token'       => $accessToken->plainTextToken,
+            'refresh_token'      => $refreshToken->plainTextToken,
+            'expires_in'         => self::ACCESS_EXPIRATION_HOURS * 3600,
+            'refresh_expires_in' => self::REFRESH_EXPIRATION_DAYS * 86400,
+        ];
+    }
+}

--- a/web/app/Actions/Auth/CreateTokenPairAction.php
+++ b/web/app/Actions/Auth/CreateTokenPairAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Auth;
 use App\Enums\TokenAbility;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Carbon\CarbonInterval;
 
 class CreateTokenPairAction
 {
@@ -36,8 +37,8 @@ class CreateTokenPairAction
         return [
             'access_token'       => $accessToken->plainTextToken,
             'refresh_token'      => $refreshToken->plainTextToken,
-            'expires_in'         => $accessExpirationHours * 3600,
-            'refresh_expires_in' => $refreshExpirationDays * 86400,
+            'expires_in'         => (int) CarbonInterval::hours($accessExpirationHours)->totalSeconds,
+            'refresh_expires_in' => (int) CarbonInterval::days($refreshExpirationDays)->totalSeconds,
         ];
     }
 }

--- a/web/app/Actions/Auth/CreateTokenPairAction.php
+++ b/web/app/Actions/Auth/CreateTokenPairAction.php
@@ -4,15 +4,12 @@ declare(strict_types = 1);
 
 namespace App\Actions\Auth;
 
+use App\Enums\TokenAbility;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 
 class CreateTokenPairAction
 {
-    public const ACCESS_EXPIRATION_HOURS = 1;
-
-    public const REFRESH_EXPIRATION_DAYS = 30;
-
     /**
      * Create a pair of tokens (access + refresh) for the user.
      *
@@ -20,25 +17,27 @@ class CreateTokenPairAction
      */
     public function execute(User $user, string $deviceName): array
     {
-        $now = CarbonImmutable::now();
+        $now                   = CarbonImmutable::now();
+        $accessExpirationHours = config('sanctum.access_token_expiration_hours');
+        $refreshExpirationDays = config('sanctum.refresh_token_expiration_days');
 
         $accessToken = $user->createToken(
-            name: "{$deviceName}:access",
-            abilities: ['access'],
-            expiresAt: $now->addHours(self::ACCESS_EXPIRATION_HOURS)
+            name: "{$deviceName}:" . TokenAbility::Access->value,
+            abilities: [TokenAbility::Access->value],
+            expiresAt: $now->addHours($accessExpirationHours)
         );
 
         $refreshToken = $user->createToken(
-            name: "{$deviceName}:refresh",
-            abilities: ['refresh'],
-            expiresAt: $now->addDays(self::REFRESH_EXPIRATION_DAYS)
+            name: "{$deviceName}:" . TokenAbility::Refresh->value,
+            abilities: [TokenAbility::Refresh->value],
+            expiresAt: $now->addDays($refreshExpirationDays)
         );
 
         return [
             'access_token'       => $accessToken->plainTextToken,
             'refresh_token'      => $refreshToken->plainTextToken,
-            'expires_in'         => self::ACCESS_EXPIRATION_HOURS * 3600,
-            'refresh_expires_in' => self::REFRESH_EXPIRATION_DAYS * 86400,
+            'expires_in'         => $accessExpirationHours * 3600,
+            'refresh_expires_in' => $refreshExpirationDays * 86400,
         ];
     }
 }

--- a/web/app/Actions/Auth/LoginAction.php
+++ b/web/app/Actions/Auth/LoginAction.php
@@ -9,6 +9,11 @@ use Illuminate\Support\Facades\Auth;
 
 class LoginAction
 {
+    public function __construct(
+        private CreateTokenPairAction $createTokenPair
+    ) {
+    }
+
     /**
      * Execute the login action.
      *
@@ -18,12 +23,14 @@ class LoginAction
     {
         $request->authenticate();
 
-        $user  = Auth::user();
-        $token = $user->createToken('mobile-app')->plainTextToken;
+        $user       = Auth::user();
+        $deviceName = $request->input('device_name', 'mobile-app');
+
+        $tokens = $this->createTokenPair->execute($user, $deviceName);
 
         return [
-            'user'  => $user,
-            'token' => $token,
+            'user' => $user,
+            ...$tokens,
         ];
     }
 }

--- a/web/app/Actions/Auth/LogoutAction.php
+++ b/web/app/Actions/Auth/LogoutAction.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace App\Actions\Auth;
 
+use App\Enums\TokenAbility;
 use App\Models\User;
 use Illuminate\Auth\AuthenticationException;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -19,17 +20,14 @@ class LogoutAction
     {
         $currentToken = $user->currentAccessToken();
 
-        // @phpstan-ignore instanceof.alwaysTrue (TransientToken pode ser retornado em contexto de teste)
+        // @phpstan-ignore instanceof.alwaysTrue (actingAs() in tests returns TransientToken)
         if (! $currentToken instanceof PersonalAccessToken) {
             throw new AuthenticationException('Token não encontrado.');
         }
 
-        $tokenName = $currentToken->name;
+        $pattern      = '/:(' . TokenAbility::Access->value . '|' . TokenAbility::Refresh->value . ')$/';
+        $devicePrefix = preg_replace($pattern, '', $currentToken->name);
 
-        // Extrair device prefix (ex: "iPhone 15" de "iPhone 15:access")
-        $devicePrefix = preg_replace('/:(access|refresh)$/', '', $tokenName);
-
-        // Revogar todos tokens deste device
         $user->tokens()
             ->where('name', 'like', "{$devicePrefix}:%")
             ->delete();

--- a/web/app/Actions/Auth/LogoutAction.php
+++ b/web/app/Actions/Auth/LogoutAction.php
@@ -6,25 +6,15 @@ namespace App\Actions\Auth;
 
 use App\Enums\TokenAbility;
 use App\Models\User;
-use Illuminate\Auth\AuthenticationException;
-use Laravel\Sanctum\PersonalAccessToken;
 
 class LogoutAction
 {
     /**
      * Revoke all tokens for the current device.
-     *
-     * @throws AuthenticationException
      */
     public function execute(User $user): void
     {
         $currentToken = $user->currentAccessToken();
-
-        // @phpstan-ignore instanceof.alwaysTrue (actingAs() in tests returns TransientToken)
-        if (! $currentToken instanceof PersonalAccessToken) {
-            throw new AuthenticationException('Token não encontrado.');
-        }
-
         $pattern      = '/:(' . TokenAbility::Access->value . '|' . TokenAbility::Refresh->value . ')$/';
         $devicePrefix = preg_replace($pattern, '', $currentToken->name);
 

--- a/web/app/Actions/Auth/LogoutAction.php
+++ b/web/app/Actions/Auth/LogoutAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\Auth;
+
+use App\Models\User;
+use Illuminate\Auth\AuthenticationException;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class LogoutAction
+{
+    /**
+     * Revoke all tokens for the current device.
+     *
+     * @throws AuthenticationException
+     */
+    public function execute(User $user): void
+    {
+        $currentToken = $user->currentAccessToken();
+
+        // @phpstan-ignore instanceof.alwaysTrue (TransientToken pode ser retornado em contexto de teste)
+        if (! $currentToken instanceof PersonalAccessToken) {
+            throw new AuthenticationException('Token não encontrado.');
+        }
+
+        $tokenName = $currentToken->name;
+
+        // Extrair device prefix (ex: "iPhone 15" de "iPhone 15:access")
+        $devicePrefix = preg_replace('/:(access|refresh)$/', '', $tokenName);
+
+        // Revogar todos tokens deste device
+        $user->tokens()
+            ->where('name', 'like', "{$devicePrefix}:%")
+            ->delete();
+    }
+}

--- a/web/app/Actions/Auth/RefreshTokenAction.php
+++ b/web/app/Actions/Auth/RefreshTokenAction.php
@@ -8,7 +8,7 @@ use App\Enums\TokenAbility;
 use App\Enums\UserStatus;
 use App\Models\User;
 use Carbon\CarbonImmutable;
-use Laravel\Sanctum\PersonalAccessToken;
+use Carbon\CarbonInterval;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class RefreshTokenAction
@@ -28,13 +28,7 @@ class RefreshTokenAction
             throw new AccessDeniedHttpException('Seu cadastro não está aprovado.');
         }
 
-        $currentToken = $user->currentAccessToken();
-
-        // @phpstan-ignore instanceof.alwaysTrue (actingAs() in tests returns TransientToken)
-        if (! $currentToken instanceof PersonalAccessToken) {
-            throw new AccessDeniedHttpException('Token de refresh inválido.');
-        }
-
+        $currentToken          = $user->currentAccessToken();
         $deviceName            = str_replace(':' . TokenAbility::Refresh->value, '', $currentToken->name);
         $accessExpirationHours = config('sanctum.access_token_expiration_hours');
 
@@ -46,7 +40,7 @@ class RefreshTokenAction
 
         return [
             'access_token' => $accessToken->plainTextToken,
-            'expires_in'   => $accessExpirationHours * 3600,
+            'expires_in'   => (int) CarbonInterval::hours($accessExpirationHours)->totalSeconds,
         ];
     }
 }

--- a/web/app/Actions/Auth/RefreshTokenAction.php
+++ b/web/app/Actions/Auth/RefreshTokenAction.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace App\Actions\Auth;
 
+use App\Enums\TokenAbility;
 use App\Enums\UserStatus;
 use App\Models\User;
 use Carbon\CarbonImmutable;
@@ -15,36 +16,37 @@ class RefreshTokenAction
     /**
      * Refresh the access token using a valid refresh token.
      *
+     * Note: Sanctum's currentAccessToken() returns the token that authenticated
+     * the current request, regardless of its ability. In this context, it's the
+     * refresh token since this endpoint requires 'abilities:refresh' middleware.
+     *
      * @return array{access_token: string, expires_in: int}
      */
     public function execute(User $user): array
     {
-        // Verificar se user ainda está aprovado
         if ($user->status !== UserStatus::Approved) {
             throw new AccessDeniedHttpException('Seu cadastro não está aprovado.');
         }
 
-        // Extrair device name do refresh token atual
         $currentToken = $user->currentAccessToken();
 
-        // @phpstan-ignore instanceof.alwaysTrue (TransientToken pode ser retornado em contexto de teste)
+        // @phpstan-ignore instanceof.alwaysTrue (actingAs() in tests returns TransientToken)
         if (! $currentToken instanceof PersonalAccessToken) {
             throw new AccessDeniedHttpException('Token de refresh inválido.');
         }
 
-        $tokenName  = $currentToken->name; // "{device}:refresh"
-        $deviceName = str_replace(':refresh', '', $tokenName);
+        $deviceName            = str_replace(':' . TokenAbility::Refresh->value, '', $currentToken->name);
+        $accessExpirationHours = config('sanctum.access_token_expiration_hours');
 
-        // Criar novo access token
         $accessToken = $user->createToken(
-            name: "{$deviceName}:access",
-            abilities: ['access'],
-            expiresAt: CarbonImmutable::now()->addHours(CreateTokenPairAction::ACCESS_EXPIRATION_HOURS)
+            name: "{$deviceName}:" . TokenAbility::Access->value,
+            abilities: [TokenAbility::Access->value],
+            expiresAt: CarbonImmutable::now()->addHours($accessExpirationHours)
         );
 
         return [
             'access_token' => $accessToken->plainTextToken,
-            'expires_in'   => CreateTokenPairAction::ACCESS_EXPIRATION_HOURS * 3600,
+            'expires_in'   => $accessExpirationHours * 3600,
         ];
     }
 }

--- a/web/app/Actions/Auth/RefreshTokenAction.php
+++ b/web/app/Actions/Auth/RefreshTokenAction.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\Auth;
+
+use App\Enums\UserStatus;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class RefreshTokenAction
+{
+    /**
+     * Refresh the access token using a valid refresh token.
+     *
+     * @return array{access_token: string, expires_in: int}
+     */
+    public function execute(User $user): array
+    {
+        // Verificar se user ainda está aprovado
+        if ($user->status !== UserStatus::Approved) {
+            throw new AccessDeniedHttpException('Seu cadastro não está aprovado.');
+        }
+
+        // Extrair device name do refresh token atual
+        $currentToken = $user->currentAccessToken();
+
+        // @phpstan-ignore instanceof.alwaysTrue (TransientToken pode ser retornado em contexto de teste)
+        if (! $currentToken instanceof PersonalAccessToken) {
+            throw new AccessDeniedHttpException('Token de refresh inválido.');
+        }
+
+        $tokenName  = $currentToken->name; // "{device}:refresh"
+        $deviceName = str_replace(':refresh', '', $tokenName);
+
+        // Criar novo access token
+        $accessToken = $user->createToken(
+            name: "{$deviceName}:access",
+            abilities: ['access'],
+            expiresAt: CarbonImmutable::now()->addHours(CreateTokenPairAction::ACCESS_EXPIRATION_HOURS)
+        );
+
+        return [
+            'access_token' => $accessToken->plainTextToken,
+            'expires_in'   => CreateTokenPairAction::ACCESS_EXPIRATION_HOURS * 3600,
+        ];
+    }
+}

--- a/web/app/Enums/TokenAbility.php
+++ b/web/app/Enums/TokenAbility.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Enums;
+
+enum TokenAbility: string
+{
+    case Access  = 'access';
+    case Refresh = 'refresh';
+}

--- a/web/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/web/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\LogoutAction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class LogoutController
+{
+    public function __invoke(Request $request, LogoutAction $action): JsonResponse
+    {
+        $action->execute($request->user());
+
+        return response()->json([
+            'message' => 'Logout realizado com sucesso',
+        ]);
+    }
+}

--- a/web/app/Http/Controllers/Api/V1/Auth/RefreshController.php
+++ b/web/app/Http/Controllers/Api/V1/Auth/RefreshController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\RefreshTokenAction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class RefreshController
+{
+    public function __invoke(Request $request, RefreshTokenAction $action): JsonResponse
+    {
+        $result = $action->execute($request->user());
+
+        return response()->json([
+            'data'    => $result,
+            'message' => 'Token renovado com sucesso',
+        ]);
+    }
+}

--- a/web/app/Http/Requests/Api/V1/Auth/LoginRequest.php
+++ b/web/app/Http/Requests/Api/V1/Auth/LoginRequest.php
@@ -32,8 +32,9 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email'    => ['required', 'string', 'email'],
-            'password' => ['required', 'string'],
+            'email'       => ['required', 'string', 'email'],
+            'password'    => ['required', 'string'],
+            'device_name' => ['sometimes', 'string', 'max:255'],
         ];
     }
 

--- a/web/app/Http/Resources/Api/V1/LoginResource.php
+++ b/web/app/Http/Resources/Api/V1/LoginResource.php
@@ -20,8 +20,11 @@ class LoginResource extends JsonResource
     {
         return [
             'data' => [
-                'user'  => UserResource::make($this->resource['user']),
-                'token' => $this->resource['token'],
+                'user'               => UserResource::make($this->resource['user']),
+                'access_token'       => $this->resource['access_token'],
+                'refresh_token'      => $this->resource['refresh_token'],
+                'expires_in'         => $this->resource['expires_in'],
+                'refresh_expires_in' => $this->resource['refresh_expires_in'],
             ],
             'message' => 'Login realizado com sucesso',
         ];

--- a/web/bootstrap/app.php
+++ b/web/bootstrap/app.php
@@ -17,8 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
-            'verified' => App\Http\Middleware\EnsureEmailIsVerified::class,
-            'approved' => App\Http\Middleware\EnsureUserIsApproved::class,
+            'verified'  => App\Http\Middleware\EnsureEmailIsVerified::class,
+            'approved'  => App\Http\Middleware\EnsureUserIsApproved::class,
+            'abilities' => Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/web/config/sanctum.php
+++ b/web/config/sanctum.php
@@ -78,4 +78,19 @@ return [
         //'validate_csrf_token'  => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Token Expiration (DoaFarma)
+    |--------------------------------------------------------------------------
+    |
+    | These values control the expiration times for access and refresh tokens.
+    | Access tokens are short-lived for security, while refresh tokens allow
+    | users to obtain new access tokens without re-authenticating.
+    |
+    */
+
+    'access_token_expiration_hours' => (int) env('SANCTUM_ACCESS_TOKEN_EXPIRATION_HOURS', 1),
+
+    'refresh_token_expiration_days' => (int) env('SANCTUM_REFRESH_TOKEN_EXPIRATION_DAYS', 30),
+
 ];

--- a/web/database/factories/UserFactory.php
+++ b/web/database/factories/UserFactory.php
@@ -94,6 +94,16 @@ class UserFactory extends Factory
     }
 
     /**
+     * Indicate that the user is approved.
+     */
+    public function approved(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => UserStatus::Approved,
+        ]);
+    }
+
+    /**
      * Indicate that the user is pending approval.
      */
     public function pending(): static

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -15,7 +15,7 @@ use App\Http\Controllers\Auth\ReceptorRegistrationController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['auth:sanctum'])->get('/user', fn (Request $request) => $request->user());
+Route::middleware(['auth:sanctum', 'abilities:access'])->get('/user', fn (Request $request) => $request->user());
 
 Route::post('/login', ApiLoginController::class)
     ->middleware('guest')
@@ -44,12 +44,8 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.auth.logout');
     });
 
-    // Routes that require authentication AND approval
-    // Note: abilities:access is NOT required here because:
-    // 1. Refresh tokens can only be used at /auth/refresh (which requires abilities:refresh)
-    // 2. The 'approved' middleware provides additional authorization
-    // 3. Tests use actingAs() which creates TransientToken without specific abilities
-    Route::middleware(['auth:sanctum', 'approved'])->group(function (): void {
+    // Routes that require authentication, approval, AND access token ability
+    Route::middleware(['auth:sanctum', 'abilities:access', 'approved'])->group(function (): void {
         Route::prefix('drugs')->group(function (): void {
             Route::get('search', Drug\SearchController::class)
                 ->name('api.v1.drugs.search');

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -34,9 +34,21 @@ Route::prefix('v1')->group(function (): void {
         Route::post('login', Auth\LoginController::class)
             ->middleware('guest')
             ->name('api.v1.auth.login');
+
+        Route::post('refresh', Auth\RefreshController::class)
+            ->middleware(['auth:sanctum', 'abilities:refresh'])
+            ->name('api.v1.auth.refresh');
+
+        Route::post('logout', Auth\LogoutController::class)
+            ->middleware(['auth:sanctum', 'abilities:access'])
+            ->name('api.v1.auth.logout');
     });
 
     // Routes that require authentication AND approval
+    // Note: abilities:access is NOT required here because:
+    // 1. Refresh tokens can only be used at /auth/refresh (which requires abilities:refresh)
+    // 2. The 'approved' middleware provides additional authorization
+    // 3. Tests use actingAs() which creates TransientToken without specific abilities
     Route::middleware(['auth:sanctum', 'approved'])->group(function (): void {
         Route::prefix('drugs')->group(function (): void {
             Route::get('search', Drug\SearchController::class)

--- a/web/tests/Feature/Api/V1/Auth/LoginTest.php
+++ b/web/tests/Feature/Api/V1/Auth/LoginTest.php
@@ -25,7 +25,10 @@ it('should authenticate users via API v1 login', function (): void {
                 'name',
                 'email',
             ],
-            'token',
+            'access_token',
+            'refresh_token',
+            'expires_in',
+            'refresh_expires_in',
         ],
         'message',
     ]);
@@ -39,9 +42,10 @@ it('should authenticate users via API v1 login', function (): void {
     expect($responseData['user']['id'])->toBe($user->id);
     expect($responseData['user']['email'])->toBe($user->email);
     expect($responseData['user']['name'])->toBe($user->name);
-    expect($responseData['token'])->toBeString();
+    expect($responseData['access_token'])->toBeString();
+    expect($responseData['refresh_token'])->toBeString();
 
-    $token                 = $responseData['token'];
+    $token                 = $responseData['access_token'];
     $authenticatedResponse = $this->withHeaders([
         'Authorization' => 'Bearer ' . $token,
     ])->getJson(route('api.v1.drugs.search'));
@@ -142,7 +146,7 @@ it('should return proper error message for invalid credentials via API v1', func
     ]);
 });
 
-it('should create token with correct abilities via API v1', function (): void {
+it('should create tokens with correct abilities via API v1', function (): void {
     $user = User::factory()->create();
 
     $response = $this->postJson('/api/v1/auth/login', [
@@ -152,9 +156,17 @@ it('should create token with correct abilities via API v1', function (): void {
 
     $response->assertSuccessful();
 
-    $token = $user->tokens()->first();
-    expect($token)->not->toBeNull();
-    expect($token->abilities)->toBe(['*']);
+    // Deve criar 2 tokens: access e refresh
+    expect($user->tokens()->count())->toBe(2);
+
+    $accessToken  = $user->tokens()->where('name', 'like', '%:access')->first();
+    $refreshToken = $user->tokens()->where('name', 'like', '%:refresh')->first();
+
+    expect($accessToken)->not->toBeNull();
+    expect($accessToken->abilities)->toBe(['access']);
+
+    expect($refreshToken)->not->toBeNull();
+    expect($refreshToken->abilities)->toBe(['refresh']);
 });
 
 it('should rate limit login attempts via API v1', function (): void {

--- a/web/tests/Feature/Api/V1/Auth/LoginWithTokenPairTest.php
+++ b/web/tests/Feature/Api/V1/Auth/LoginWithTokenPairTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Laravel\Sanctum\PersonalAccessToken;
+
+describe('POST /api/v1/auth/login - token pair', function (): void {
+    describe('response structure', function (): void {
+        it('should return access_token and refresh_token on successful login', function (): void {
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'       => $user->email,
+                'password'    => 'password',
+                'device_name' => 'iPhone-15',
+            ]);
+
+            $response->assertSuccessful();
+            $response->assertJsonStructure([
+                'data' => [
+                    'user' => [
+                        'id',
+                        'name',
+                        'email',
+                    ],
+                    'access_token',
+                    'refresh_token',
+                    'expires_in',
+                    'refresh_expires_in',
+                ],
+                'message',
+            ]);
+        });
+
+        it('should return correct expiration times', function (): void {
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $data = $response->json('data');
+
+            // Access token expira em 1 hora (3600 segundos)
+            expect($data['expires_in'])->toBe(3600);
+
+            // Refresh token expira em 30 dias (2592000 segundos)
+            expect($data['refresh_expires_in'])->toBe(2592000);
+        });
+
+        it('should use default device name when not provided', function (): void {
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $response->assertSuccessful();
+
+            // Verificar que tokens foram criados com device name padrão
+            expect(PersonalAccessToken::where('name', 'mobile-app:access')->exists())->toBeTrue();
+            expect(PersonalAccessToken::where('name', 'mobile-app:refresh')->exists())->toBeTrue();
+        });
+    });
+
+    describe('token creation', function (): void {
+        it('should create access token with correct abilities', function (): void {
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'       => $user->email,
+                'password'    => 'password',
+                'device_name' => 'test-device',
+            ]);
+
+            $accessTokenRecord = PersonalAccessToken::where('name', 'test-device:access')->first();
+
+            expect($accessTokenRecord)->not->toBeNull();
+            expect($accessTokenRecord->abilities)->toBe(['access']);
+        });
+
+        it('should create refresh token with correct abilities', function (): void {
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'       => $user->email,
+                'password'    => 'password',
+                'device_name' => 'test-device',
+            ]);
+
+            $refreshTokenRecord = PersonalAccessToken::where('name', 'test-device:refresh')->first();
+
+            expect($refreshTokenRecord)->not->toBeNull();
+            expect($refreshTokenRecord->abilities)->toBe(['refresh']);
+        });
+
+        it('should create access token with correct expiration', function (): void {
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 12:00:00'));
+
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'       => $user->email,
+                'password'    => 'password',
+                'device_name' => 'test-device',
+            ]);
+
+            $accessTokenRecord = PersonalAccessToken::where('name', 'test-device:access')->first();
+
+            expect($accessTokenRecord->expires_at)->not->toBeNull();
+            expect($accessTokenRecord->expires_at->toDateTimeString())->toBe('2026-01-28 13:00:00');
+
+            CarbonImmutable::setTestNow();
+        });
+
+        it('should create refresh token with correct expiration', function (): void {
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 12:00:00'));
+
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'       => $user->email,
+                'password'    => 'password',
+                'device_name' => 'test-device',
+            ]);
+
+            $refreshTokenRecord = PersonalAccessToken::where('name', 'test-device:refresh')->first();
+
+            expect($refreshTokenRecord->expires_at)->not->toBeNull();
+            expect($refreshTokenRecord->expires_at->toDateTimeString())->toBe('2026-02-27 12:00:00');
+
+            CarbonImmutable::setTestNow();
+        });
+    });
+
+    describe('token usage', function (): void {
+        it('should allow authenticated requests with access token', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $accessToken = $response->json('data.access_token');
+
+            $authenticatedResponse = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken,
+            ])->getJson(route('api.v1.drugs.search'));
+
+            $authenticatedResponse->assertSuccessful();
+        });
+
+        it('should not allow refresh token for logout endpoint', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $refreshToken = $response->json('data.refresh_token');
+
+            // Limpar sessão web para simular requisições independentes (como app mobile)
+            auth()->guard('web')->logout();
+
+            // Refresh token não deve funcionar para logout (requer abilities:access)
+            $logoutResponse = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            $logoutResponse->assertForbidden();
+        });
+
+        it('should allow refresh with refresh token', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $refreshToken = $response->json('data.refresh_token');
+
+            // Limpar sessão web para simular requisições independentes (como app mobile)
+            auth()->guard('web')->logout();
+
+            $refreshResponse = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $refreshResponse->assertOk();
+            $refreshResponse->assertJsonStructure([
+                'data' => [
+                    'access_token',
+                    'expires_in',
+                ],
+            ]);
+        });
+    });
+
+    describe('validation', function (): void {
+        it('should accept device_name as optional parameter', function (): void {
+            $user = User::factory()->create();
+
+            // Sem device_name
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $response->assertSuccessful();
+        });
+
+        it('should reject device_name longer than 255 characters', function (): void {
+            $user = User::factory()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'       => $user->email,
+                'password'    => 'password',
+                'device_name' => str_repeat('a', 256),
+            ]);
+
+            $response->assertUnprocessable();
+            $response->assertJsonValidationErrors(['device_name']);
+        });
+    });
+});

--- a/web/tests/Feature/Api/V1/Auth/LogoutTest.php
+++ b/web/tests/Feature/Api/V1/Auth/LogoutTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Laravel\Sanctum\PersonalAccessToken;
+
+describe('POST /api/v1/auth/logout', function (): void {
+    describe('happy path', function (): void {
+        it('should revoke tokens and return success', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            $response->assertOk();
+            $response->assertJson([
+                'message' => 'Logout realizado com sucesso',
+            ]);
+        });
+
+        it('should revoke all tokens for the device', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar par de tokens (access + refresh) para um device
+            $accessToken = $user->createToken(
+                name: 'iPhone-15:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            $refreshToken = $user->createToken(
+                name: 'iPhone-15:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            // Verificar que os tokens existem
+            expect(PersonalAccessToken::where('name', 'iPhone-15:access')->exists())->toBeTrue();
+            expect(PersonalAccessToken::where('name', 'iPhone-15:refresh')->exists())->toBeTrue();
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            $response->assertOk();
+
+            // Verificar que ambos tokens foram revogados
+            expect(PersonalAccessToken::where('name', 'iPhone-15:access')->exists())->toBeFalse();
+            expect(PersonalAccessToken::where('name', 'iPhone-15:refresh')->exists())->toBeFalse();
+        });
+
+        it('should not revoke tokens from other devices', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Tokens do iPhone
+            $iphoneAccess = $user->createToken(
+                name: 'iPhone-15:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+            $user->createToken(
+                name: 'iPhone-15:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            // Tokens do Android (outro device)
+            $user->createToken(
+                name: 'Android-Phone:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+            $user->createToken(
+                name: 'Android-Phone:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            // Logout do iPhone
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $iphoneAccess->plainTextToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            $response->assertOk();
+
+            // Tokens do iPhone foram revogados
+            expect(PersonalAccessToken::where('name', 'iPhone-15:access')->exists())->toBeFalse();
+            expect(PersonalAccessToken::where('name', 'iPhone-15:refresh')->exists())->toBeFalse();
+
+            // Tokens do Android ainda existem
+            expect(PersonalAccessToken::where('name', 'Android-Phone:access')->exists())->toBeTrue();
+            expect(PersonalAccessToken::where('name', 'Android-Phone:refresh')->exists())->toBeTrue();
+        });
+    });
+
+    describe('post logout behavior', function (): void {
+        it('should delete access and refresh tokens from database', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            // Verificar que tokens existem antes do logout
+            expect(PersonalAccessToken::where('name', 'test-device:access')->exists())->toBeTrue();
+            expect(PersonalAccessToken::where('name', 'test-device:refresh')->exists())->toBeTrue();
+
+            // Fazer logout
+            $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            // Verificar que AMBOS os tokens foram deletados do banco
+            expect(PersonalAccessToken::where('name', 'test-device:access')->exists())->toBeFalse();
+            expect(PersonalAccessToken::where('name', 'test-device:refresh')->exists())->toBeFalse();
+
+            // O Sanctum automaticamente rejeita tokens que não existem no banco
+            // Não precisamos testar isso aqui - é comportamento interno do Sanctum
+        });
+    });
+
+    describe('authentication required', function (): void {
+        it('should reject logout without token', function (): void {
+            $response = $this->postJson('/api/v1/auth/logout');
+
+            $response->assertUnauthorized();
+        });
+
+        it('should reject logout with invalid token', function (): void {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer invalid-token',
+            ])->postJson('/api/v1/auth/logout');
+
+            $response->assertUnauthorized();
+        });
+
+        it('should reject logout with refresh token', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Usar refresh token ao invés de access token
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            // Deve falhar porque refresh token não tem ability 'access'
+            $response->assertForbidden();
+        });
+    });
+});

--- a/web/tests/Feature/Api/V1/Auth/RefreshTokenTest.php
+++ b/web/tests/Feature/Api/V1/Auth/RefreshTokenTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enums\UserStatus;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Response;
+use Laravel\Sanctum\PersonalAccessToken;
+
+describe('POST /api/v1/auth/refresh', function (): void {
+    describe('happy path', function (): void {
+        it('should return new access token when refresh token is valid', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar refresh token manualmente (simulando o que o login faria)
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertOk();
+            $response->assertJsonStructure([
+                'data' => [
+                    'access_token',
+                    'expires_in',
+                ],
+                'message',
+            ]);
+
+            $data = $response->json('data');
+            expect($data['access_token'])->toBeString();
+            expect($data['expires_in'])->toBe(3600); // 1 hour in seconds
+        });
+
+        it('should create access token with correct abilities', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertOk();
+
+            // Verificar que o novo token tem ability 'access'
+            $newTokenString = $response->json('data.access_token');
+            $tokenId        = explode('|', $newTokenString)[0];
+            $newToken       = PersonalAccessToken::find($tokenId);
+
+            expect($newToken)->not->toBeNull();
+            expect($newToken->abilities)->toBe(['access']);
+            expect($newToken->name)->toBe('test-device:access');
+        });
+
+        it('should create access token with correct expiration', function (): void {
+            $user = User::factory()->approved()->create();
+
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 12:00:00'));
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertOk();
+
+            $newTokenString = $response->json('data.access_token');
+            $tokenId        = explode('|', $newTokenString)[0];
+            $newToken       = PersonalAccessToken::find($tokenId);
+
+            expect($newToken->expires_at)->not->toBeNull();
+            expect($newToken->expires_at->toDateTimeString())->toBe('2026-01-28 13:00:00');
+
+            CarbonImmutable::setTestNow();
+        });
+
+        it('should create new access token with correct properties', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $newAccessToken = $response->json('data.access_token');
+
+            // Verificar que o novo token foi criado corretamente
+            $tokenId     = explode('|', $newAccessToken)[0];
+            $tokenRecord = PersonalAccessToken::find($tokenId);
+
+            expect($tokenRecord)->not->toBeNull();
+            expect($tokenRecord->name)->toBe('test-device:access');
+            expect($tokenRecord->abilities)->toBe(['access']);
+            expect($tokenRecord->expires_at)->not->toBeNull();
+            expect($tokenRecord->tokenable_id)->toBe($user->id);
+
+            // O token foi criado corretamente no banco
+            // O Sanctum automaticamente permite autenticação com tokens válidos no banco
+        });
+    });
+
+    describe('token validation', function (): void {
+        it('should reject expired refresh token with 401', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar refresh token já expirado
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->subDay() // Expirado ontem
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertUnauthorized();
+        });
+
+        it('should reject access token used for refresh with 401', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar access token (não refresh)
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            // Deve falhar porque o token não tem ability 'refresh'
+            $response->assertStatus(Response::HTTP_FORBIDDEN);
+        });
+
+        it('should reject invalid token with 401', function (): void {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer invalid-token-here',
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertUnauthorized();
+        });
+
+        it('should reject request without token with 401', function (): void {
+            $response = $this->postJson('/api/v1/auth/refresh');
+
+            $response->assertUnauthorized();
+        });
+    });
+
+    describe('user status validation', function (): void {
+        it('should reject refresh for pending user with 403', function (): void {
+            $user = User::factory()->pending()->create();
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertForbidden();
+            $response->assertJson([
+                'message' => 'Seu cadastro não está aprovado.',
+            ]);
+        });
+
+        it('should reject refresh for rejected user with 403', function (): void {
+            $user = User::factory()->rejected()->create();
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertForbidden();
+        });
+
+        it('should reject refresh when user was approved but later rejected', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            // Simula admin rejeitando o usuário depois que ele já tinha token
+            $user->update(['status' => UserStatus::Rejected]);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertForbidden();
+        });
+    });
+});

--- a/web/tests/Feature/Api/V1/Auth/TokenConfigTest.php
+++ b/web/tests/Feature/Api/V1/Auth/TokenConfigTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterval;
+use Illuminate\Support\Facades\Config;
+use Laravel\Sanctum\PersonalAccessToken;
+
+describe('token configuration', function (): void {
+    describe('access token expiration config', function (): void {
+        it('should use configured expiration hours for access token', function (): void {
+            Config::set('sanctum.access_token_expiration_hours', 2);
+
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 10:00:00'));
+
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $response->assertOk();
+
+            $accessTokenString = $response->json('data.access_token');
+            $tokenId           = explode('|', $accessTokenString)[0];
+            $token             = PersonalAccessToken::find($tokenId);
+
+            expect($token->expires_at->toDateTimeString())->toBe('2026-01-28 12:00:00');
+            expect($response->json('data.expires_in'))->toBe(7200);
+
+            CarbonImmutable::setTestNow();
+        });
+
+        it('should use default 1 hour when config is not set', function (): void {
+            Config::set('sanctum.access_token_expiration_hours', 1);
+
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 10:00:00'));
+
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $response->assertOk();
+            expect($response->json('data.expires_in'))->toBe(3600);
+
+            CarbonImmutable::setTestNow();
+        });
+    });
+
+    describe('refresh token expiration config', function (): void {
+        it('should use configured expiration days for refresh token', function (): void {
+            Config::set('sanctum.refresh_token_expiration_days', 7);
+
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 10:00:00'));
+
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $response->assertOk();
+
+            $refreshTokenString = $response->json('data.refresh_token');
+            $tokenId            = explode('|', $refreshTokenString)[0];
+            $token              = PersonalAccessToken::find($tokenId);
+
+            expect($token->expires_at->toDateTimeString())->toBe('2026-02-04 10:00:00');
+            expect($response->json('data.refresh_expires_in'))->toBe((int) CarbonInterval::days(7)->totalSeconds);
+
+            CarbonImmutable::setTestNow();
+        });
+
+        it('should use default 30 days when config is not set', function (): void {
+            Config::set('sanctum.refresh_token_expiration_days', 30);
+
+            $user = User::factory()->approved()->create();
+
+            $response = $this->postJson('/api/v1/auth/login', [
+                'email'    => $user->email,
+                'password' => 'password',
+            ]);
+
+            $response->assertOk();
+            expect($response->json('data.refresh_expires_in'))->toBe((int) CarbonInterval::days(30)->totalSeconds);
+        });
+    });
+
+    describe('refresh endpoint respects config', function (): void {
+        it('should create new access token with configured expiration', function (): void {
+            Config::set('sanctum.access_token_expiration_hours', 3);
+
+            CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-01-28 10:00:00'));
+
+            $user = User::factory()->approved()->create();
+
+            $refreshToken = $user->createToken(
+                name: 'test-device:refresh',
+                abilities: ['refresh'],
+                expiresAt: CarbonImmutable::now()->addDays(30)
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $refreshToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            $response->assertOk();
+
+            $accessTokenString = $response->json('data.access_token');
+            $tokenId           = explode('|', $accessTokenString)[0];
+            $token             = PersonalAccessToken::find($tokenId);
+
+            expect($token->expires_at->toDateTimeString())->toBe('2026-01-28 13:00:00');
+            expect($response->json('data.expires_in'))->toBe(10800);
+
+            CarbonImmutable::setTestNow();
+        });
+    });
+});

--- a/web/tests/Feature/Api/V1/Auth/TokenExpirationTest.php
+++ b/web/tests/Feature/Api/V1/Auth/TokenExpirationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+describe('token expiration', function (): void {
+    describe('access token expiration', function (): void {
+        it('should reject expired access token with 401', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar access token já expirado
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->subMinute() // Expirado
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->getJson(route('api.v1.drugs.search'));
+
+            $response->assertUnauthorized();
+        });
+
+        it('should accept valid non-expired access token', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar access token válido
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->getJson(route('api.v1.drugs.search'));
+
+            $response->assertSuccessful();
+        });
+
+        it('should reject access token about to expire', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Token que expira em 1 segundo
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addSecond()
+            );
+
+            // Esperar o token expirar
+            sleep(2);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->getJson(route('api.v1.drugs.search'));
+
+            $response->assertUnauthorized();
+        });
+    });
+
+    describe('token abilities', function (): void {
+        it('should reject refresh token used for refresh endpoint when using access token', function (): void {
+            $user = User::factory()->approved()->create();
+
+            // Criar access token (não refresh)
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            // Tentar usar access token para refresh
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->postJson('/api/v1/auth/refresh');
+
+            // Deve falhar porque access token não tem ability 'refresh'
+            $response->assertForbidden();
+        });
+
+        it('should allow access token for logout endpoint', function (): void {
+            $user = User::factory()->approved()->create();
+
+            $accessToken = $user->createToken(
+                name: 'test-device:access',
+                abilities: ['access'],
+                expiresAt: CarbonImmutable::now()->addHour()
+            );
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken->plainTextToken,
+            ])->postJson('/api/v1/auth/logout');
+
+            $response->assertOk();
+        });
+    });
+});

--- a/web/tests/Feature/Api/V1/DoctorRating/ListTest.php
+++ b/web/tests/Feature/Api/V1/DoctorRating/ListTest.php
@@ -43,7 +43,7 @@ it('should list all ratings for a doctor', function (): void {
         ]));
     }
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/doctor/{$doctor->id}");
 
@@ -55,7 +55,7 @@ it('should return empty array when doctor has no ratings', function (): void {
     $doctor   = Doctor::factory()->create();
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/doctor/{$doctor->id}");
 
@@ -99,7 +99,7 @@ it('should return ratings ordered by most recent first', function (): void {
         'created_at'                => now(),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/doctor/{$doctor->id}");
 
@@ -127,7 +127,7 @@ it('should include receptor name in response', function (): void {
         'receptor_id'               => $receptor->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/doctor/{$doctor->id}");
 
@@ -147,7 +147,7 @@ it('should return 401 for unauthenticated users', function (): void {
 it('should allow doctors to view their own ratings', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     getJson("/api/v1/doctor-ratings/doctor/{$doctor->id}")
         ->assertOk();
@@ -157,7 +157,7 @@ it('should allow receptors to view doctor ratings', function (): void {
     $doctor   = Doctor::factory()->create();
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson("/api/v1/doctor-ratings/doctor/{$doctor->id}")
         ->assertOk();
@@ -168,7 +168,7 @@ it('should allow receptors to view doctor ratings', function (): void {
 it('should return 404 for non-existent doctor', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/doctor-ratings/doctor/99999')
         ->assertNotFound();
@@ -207,7 +207,7 @@ it('should only show ratings for the specified doctor', function (): void {
         'receptor_id'               => $receptor->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/doctor/{$doctor1->id}");
 

--- a/web/tests/Feature/Api/V1/DoctorRating/MyRatingsTest.php
+++ b/web/tests/Feature/Api/V1/DoctorRating/MyRatingsTest.php
@@ -42,7 +42,7 @@ it('should return ratings for authenticated doctor', function (): void {
     createRatingForDoctor($doctor, $receptor, 4);
     createRatingForDoctor($doctor, $receptor, 5);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -77,7 +77,7 @@ it('should calculate correct summary statistics', function (): void {
     createRatingForDoctor($doctor, $receptor, 3);
     createRatingForDoctor($doctor, $receptor, 2);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -94,7 +94,7 @@ it('should calculate correct summary statistics', function (): void {
 it('should return empty ratings for doctor with no ratings', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -140,7 +140,7 @@ it('should return ratings ordered by most recent first', function (): void {
         'created_at'                => now(),
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -155,7 +155,7 @@ it('should include receptor information', function (): void {
 
     createRatingForDoctor($doctor, $receptor, 5);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -169,7 +169,7 @@ it('should include medication appointment information', function (): void {
 
     createRatingForDoctor($doctor, $receptor, 5);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -193,7 +193,7 @@ it('should return 401 for unauthenticated users', function (): void {
 it('should return 403 for receptor users', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/doctor-ratings/my-ratings')
         ->assertForbidden()
@@ -212,7 +212,7 @@ it('should only return ratings for the authenticated doctor', function (): void 
     // Create rating for doctor2
     createRatingForDoctor($doctor2, $receptor, 3);
 
-    actingAs($doctor1->user);
+    actingAs($doctor1->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -242,7 +242,7 @@ it('should handle ratings with null comments', function (): void {
         'rating'                    => 5,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 
@@ -260,7 +260,7 @@ it('should correctly round average to one decimal place', function (): void {
     createRatingForDoctor($doctor, $receptor, 4);
     createRatingForDoctor($doctor, $receptor, 3);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/doctor-ratings/my-ratings');
 

--- a/web/tests/Feature/Api/V1/DoctorRating/ShowByAppointmentTest.php
+++ b/web/tests/Feature/Api/V1/DoctorRating/ShowByAppointmentTest.php
@@ -37,7 +37,7 @@ it('should return null when appointment has no rating', function (): void {
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointmentForShow($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/appointment/{$appointment->id}");
 
@@ -58,7 +58,7 @@ it('should return existing rating when appointment has been rated', function ():
         'comment'                   => 'Excelente!',
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson("/api/v1/doctor-ratings/appointment/{$appointment->id}");
 
@@ -83,7 +83,7 @@ it('should return 403 when receptor checks another receptors appointment', funct
     $receptor2   = User::factory()->receptor()->create();
     $appointment = createCompletedAppointmentForShow($receptor1);
 
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
 
     getJson("/api/v1/doctor-ratings/appointment/{$appointment->id}")
         ->assertForbidden();
@@ -94,7 +94,7 @@ it('should return 403 when receptor checks another receptors appointment', funct
 it('should return 404 for non-existent appointment', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/doctor-ratings/appointment/99999')
         ->assertNotFound();

--- a/web/tests/Feature/Api/V1/DoctorRating/StoreTest.php
+++ b/web/tests/Feature/Api/V1/DoctorRating/StoreTest.php
@@ -38,7 +38,7 @@ it('should allow receptor to rate a doctor after completed appointment', functio
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating'  => 5,
@@ -60,7 +60,7 @@ it('should allow rating without comment', function (): void {
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 4,
@@ -76,7 +76,7 @@ it('should return correct doctor and receptor info in response', function (): vo
     $doctor      = Doctor::factory()->create();
     $appointment = createCompletedAppointment($receptor, $doctor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 5,
@@ -93,7 +93,7 @@ it('should return 422 when rating is missing', function (): void {
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [])
         ->assertStatus(422)
@@ -104,7 +104,7 @@ it('should return 422 when rating is below 1', function (): void {
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 0,
@@ -117,7 +117,7 @@ it('should return 422 when rating is above 5', function (): void {
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 6,
@@ -130,7 +130,7 @@ it('should return 422 when comment exceeds max length', function (): void {
     $receptor    = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating'  => 5,
@@ -157,7 +157,7 @@ it('should return 403 when doctor tries to rate themselves', function (): void {
     $doctor      = Doctor::factory()->create();
     $appointment = createCompletedAppointment($receptor, $doctor);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 5,
@@ -170,7 +170,7 @@ it('should return 403 when receptor tries to rate another receptors appointment'
     $receptor2   = User::factory()->receptor()->create();
     $appointment = createCompletedAppointment($receptor1);
 
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 5,
@@ -195,7 +195,7 @@ it('should return 422 when appointment is not completed', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 5,
@@ -217,7 +217,7 @@ it('should return 409 when rating already exists for appointment', function (): 
         'rating'                    => 4,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson("/api/v1/doctor-ratings/{$appointment->id}", [
         'rating' => 5,
@@ -231,7 +231,7 @@ it('should return 409 when rating already exists for appointment', function (): 
 it('should return 404 for non-existent appointment', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/doctor-ratings/99999', [
         'rating' => 5,
@@ -244,7 +244,7 @@ it('should accept all valid ratings from 1 to 5', function (): void {
         $receptor    = User::factory()->receptor()->create();
         $appointment = createCompletedAppointment($receptor);
 
-        actingAs($receptor);
+        actingAs($receptor, 'sanctum');
 
         postJson("/api/v1/doctor-ratings/{$appointment->id}", [
             'rating' => $rating,

--- a/web/tests/Feature/Api/V1/DoctorRating/UpdateTest.php
+++ b/web/tests/Feature/Api/V1/DoctorRating/UpdateTest.php
@@ -45,7 +45,7 @@ it('should allow receptor to update rating', function (): void {
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'rating' => 5,
@@ -64,7 +64,7 @@ it('should allow receptor to update comment', function (): void {
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'comment' => 'Updated comment',
@@ -83,7 +83,7 @@ it('should allow receptor to update both rating and comment', function (): void 
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'rating'  => 4,
@@ -99,7 +99,7 @@ it('should allow removing comment by setting to null', function (): void {
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'comment' => null,
@@ -120,7 +120,7 @@ it('should return 422 when rating is below 1', function (): void {
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'rating' => 0,
@@ -133,7 +133,7 @@ it('should return 422 when rating is above 5', function (): void {
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'rating' => 6,
@@ -146,7 +146,7 @@ it('should return 422 when comment exceeds max length', function (): void {
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'comment' => str_repeat('a', 1001),
@@ -172,7 +172,7 @@ it('should return 403 when receptor tries to update another receptors rating', f
     $receptor2 = User::factory()->receptor()->create();
     $rating    = createRatingForUpdate($receptor1);
 
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
 
     patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'rating' => 5,
@@ -185,7 +185,7 @@ it('should return 403 when doctor tries to update rating', function (): void {
     $doctor   = Doctor::factory()->create();
     $rating   = createRatingForUpdate($receptor, $doctor);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/doctor-ratings/{$rating->id}", [
         'rating' => 5,
@@ -198,7 +198,7 @@ it('should return 403 when doctor tries to update rating', function (): void {
 it('should return 404 for non-existent rating', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson('/api/v1/doctor-ratings/99999', [
         'rating' => 5,
@@ -210,7 +210,7 @@ it('should keep original values when updating with empty payload', function (): 
     $receptor = User::factory()->receptor()->create();
     $rating   = createRatingForUpdate($receptor);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/doctor-ratings/{$rating->id}", []);
 

--- a/web/tests/Feature/Api/V1/Drug/ListTest.php
+++ b/web/tests/Feature/Api/V1/Drug/ListTest.php
@@ -11,7 +11,7 @@ use function Pest\Laravel\getJson;
 it('should be accessible via GET /api/v1/drugs', function (): void {
     $user = User::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     getJson('/api/v1/drugs')
         ->assertOk();
@@ -33,7 +33,7 @@ it('should return 200 and correct JSON structure for valid query', function (): 
         'laboratory'   => 'EMS',
     ]);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = getJson('/api/v1/drugs');
 

--- a/web/tests/Feature/Api/V1/Drug/SearchTest.php
+++ b/web/tests/Feature/Api/V1/Drug/SearchTest.php
@@ -10,7 +10,7 @@ use function Pest\Laravel\getJson;
 
 it('should be accessible via GET /api/v1/drugs/search', function (): void {
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
     getJson('/api/v1/drugs/search')
         ->assertOk();
 
@@ -23,7 +23,7 @@ it('should require authentication', function (): void {
         ->assertUnauthorized();
 
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
     getJson('/api/v1/drugs/search')
         ->assertOk();
 });
@@ -49,7 +49,7 @@ it('should return 200 and correct JSON structure for valid query', function (): 
         'laboratory'   => 'Ache',
     ]);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $q        = 'Paracetamol';
     $response = getJson('/api/v1/drugs/search?q=' . urlencode($q));
@@ -77,7 +77,7 @@ it('should return paginated results', function (): void {
     $total = 25;
     Drug::factory()->count($total)->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $perPage  = 10;
     $response = getJson('/api/v1/drugs/search?per_page=' . $perPage);
@@ -108,7 +108,7 @@ it('should support sorting results', function (): void {
     $c = Drug::factory()->create(['product_name' => 'Cataflam', 'substance' => 'Diclofenaco', 'laboratory' => 'Lab C']);
     $b = Drug::factory()->create(['product_name' => 'Ben-u-ron', 'substance' => 'Paracetamol', 'laboratory' => 'Lab B']);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     // ascending
     $respAsc = getJson('/api/v1/drugs/search?sort=product_name&order=asc');
@@ -132,7 +132,7 @@ it('should return empty data if no matches found', function (): void {
     Drug::factory()->create(['product_name' => 'Ibuprofeno 400mg', 'substance' => 'Ibuprofeno', 'laboratory' => 'Ache']);
     Drug::factory()->create(['product_name' => 'Cetirizina', 'substance' => 'Cetirizina', 'laboratory' => 'LabX']);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = getJson('/api/v1/drugs/search?q=' . urlencode('TermoInexistente'));
 
@@ -152,7 +152,7 @@ it('should return empty data if no matches found', function (): void {
 
 it('should return validation error for invalid query params', function (): void {
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = getJson('/api/v1/drugs/search?per_page=0&sort=unknown');
 
@@ -162,7 +162,7 @@ it('should return validation error for invalid query params', function (): void 
 
 it('should return correct Content-Type header', function (): void {
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = getJson('/api/v1/drugs/search');
     $response->assertOk();
@@ -186,7 +186,7 @@ it('should support partial matches in drug name', function (): void {
         'laboratory'   => 'Ache',
     ]);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = getJson('/api/v1/drugs/search?q=' . urlencode('acetamol'));
     $response->assertOk();
@@ -219,7 +219,7 @@ it('should support multiple filters combined', function (): void {
         'laboratory'   => 'Lab3',
     ]);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $perPage   = 1;
     $baseQuery = http_build_query([
@@ -259,7 +259,7 @@ it('should support multiple filters combined', function (): void {
 
 it('should respect per_page pagination parameter', function (): void {
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $total = 12;
     Drug::factory()->count($total)->create();
@@ -280,7 +280,7 @@ it('should respect per_page pagination parameter', function (): void {
 
 it('should return correct total count in pagination meta', function (): void {
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     // matching records
     Drug::factory()->count(12)->create(['product_name' => 'MatchMe', 'substance' => 'S', 'laboratory' => 'L']);
@@ -300,7 +300,7 @@ it('should return correct total count in pagination meta', function (): void {
 
 it('should not leak sensitive fields', function (): void {
     $user = User::factory()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $drug = Drug::factory()->create([
         'product_name' => 'SecretDrug',
@@ -340,7 +340,7 @@ it('should support searching by active ingredient', function (): void {
         'laboratory'   => 'LabB',
     ]);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $resp = getJson('/api/v1/drugs/search?q=' . urlencode('dipirona'));
     $resp->assertOk();
@@ -362,7 +362,7 @@ it('should support searching by manufacturer', function (): void {
 
     // NOTE: controller currently searches product_name and substance only.
     // This test documents desired behavior (will fail until controller is extended to include laboratory).
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $resp = getJson('/api/v1/drugs/search?q=' . urlencode('ACME'));
     $resp->assertOk();
@@ -382,7 +382,7 @@ it('should support case-insensitive search', function (): void {
         'laboratory'   => 'LabCI',
     ]);
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $resp = getJson('/api/v1/drugs/search?q=' . urlencode('paracetamol'));
     $resp->assertOk();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/AcceptTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/AcceptTest.php
@@ -32,7 +32,7 @@ it('should allow doctor to accept receptor proposal', function (): void {
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertOk()
@@ -58,7 +58,7 @@ it('should allow receptor to accept doctor counter-proposal', function (): void 
             'address_id'            => $address->id,
         ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertOk()
@@ -84,7 +84,7 @@ it('should return appointment with all related data after accept', function (): 
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertOk()
@@ -130,7 +130,7 @@ it('should return 403 when receptor tries to accept own proposal', function (): 
             'address_id'            => $address->id,
         ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertForbidden();
@@ -154,7 +154,7 @@ it('should return 403 when doctor tries to accept own counter-proposal', functio
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertForbidden();
@@ -179,7 +179,7 @@ it('should return 403 when doctor tries to accept another doctors appointment', 
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctorB->user);
+    actingAs($doctorB->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertForbidden();
@@ -204,7 +204,7 @@ it('should return 403 when receptor tries to accept another receptors appointmen
             'address_id'            => $address->id,
         ]);
 
-    actingAs($receptorB);
+    actingAs($receptorB, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertForbidden();
@@ -230,7 +230,7 @@ it('should return 422 when trying to accept already confirmed appointment', func
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertStatus(422)
@@ -254,7 +254,7 @@ it('should return 422 when trying to accept completed appointment', function ():
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/accept")
         ->assertStatus(422);
@@ -263,7 +263,7 @@ it('should return 422 when trying to accept completed appointment', function ():
 it('should return 404 when trying to accept non-existent appointment', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson('/api/v1/medication-appointments/99999/accept')
         ->assertNotFound();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/ConfirmDeliveryDoctorTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/ConfirmDeliveryDoctorTest.php
@@ -30,7 +30,7 @@ it('should allow doctor to confirm delivery', function (): void {
         'scheduled_date'        => now()->subDays(1)->toDateString(),
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor");
 
@@ -56,7 +56,7 @@ it('should complete appointment and offering when both confirm', function (): vo
         'receptor_confirmed'    => true,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor")
         ->assertOk()
@@ -93,7 +93,7 @@ it('should return 403 when receptor tries to confirm as doctor', function (): vo
         'scheduled_date'        => now()->subDays(1)->toDateString(),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor")
         ->assertForbidden();
@@ -116,7 +116,7 @@ it('should return 403 when doctor confirms another doctors appointment', functio
         'scheduled_date'        => now()->subDays(1)->toDateString(),
     ]);
 
-    actingAs($doctorB->user);
+    actingAs($doctorB->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor")
         ->assertForbidden();
@@ -139,7 +139,7 @@ it('should return 422 when appointment is already completed', function (): void 
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor")
         ->assertStatus(422)
@@ -162,7 +162,7 @@ it('should return 422 when confirming before scheduled date', function (): void 
         'scheduled_date'        => now()->addDays(5)->toDateString(),
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor")
         ->assertStatus(422)
@@ -186,7 +186,7 @@ it('should return 422 when doctor already confirmed', function (): void {
         'doctor_confirmed'      => true,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-doctor")
         ->assertStatus(422)

--- a/web/tests/Feature/Api/V1/MedicationAppointment/ConfirmDeliveryReceptorTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/ConfirmDeliveryReceptorTest.php
@@ -30,7 +30,7 @@ it('should allow receptor to confirm delivery', function (): void {
         'scheduled_date'        => now()->subDays(1)->toDateString(),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor");
 
@@ -56,7 +56,7 @@ it('should complete appointment when both parties confirm', function (): void {
         'doctor_confirmed'      => true,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor");
 
@@ -86,7 +86,7 @@ it('should allow confirmation on scheduled date', function (): void {
         'scheduled_date'        => now()->toDateString(),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor")
         ->assertOk();
@@ -119,7 +119,7 @@ it('should return 403 when doctor tries to confirm as receptor', function (): vo
         'scheduled_date'        => now()->subDays(1)->toDateString(),
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor")
         ->assertForbidden();
@@ -142,7 +142,7 @@ it('should return 403 when receptor confirms another receptors appointment', fun
         'scheduled_date'        => now()->subDays(1)->toDateString(),
     ]);
 
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor")
         ->assertForbidden();
@@ -165,7 +165,7 @@ it('should return 422 when appointment is already completed', function (): void 
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor")
         ->assertStatus(422)
@@ -188,7 +188,7 @@ it('should return 422 when confirming before scheduled date', function (): void 
         'scheduled_date'        => now()->addDays(5)->toDateString(),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor")
         ->assertStatus(422)
@@ -212,7 +212,7 @@ it('should return 422 when receptor already confirmed', function (): void {
         'receptor_confirmed'    => true,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/confirm-delivery-receptor")
         ->assertStatus(422)
@@ -224,7 +224,7 @@ it('should return 422 when receptor already confirmed', function (): void {
 it('should return 404 for non-existent appointment', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson('/api/v1/medication-appointments/99999/confirm-delivery-receptor')
         ->assertNotFound();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/CounterProposeTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/CounterProposeTest.php
@@ -37,7 +37,7 @@ it('should allow doctor to counter-propose with new date and time', function ():
 
     $newDate = Carbon::now()->addDays(7)->toDateString();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => $newDate,
@@ -71,7 +71,7 @@ it('should allow doctor to counter-propose with new address', function (): void 
 
     $newDate = Carbon::now()->addDays(3)->toDateString();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => $newDate,
@@ -102,7 +102,7 @@ it('should allow receptor to counter-propose after doctor', function (): void {
 
     $newDate = Carbon::now()->addDays(10)->toDateString();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => $newDate,
@@ -135,7 +135,7 @@ it('should preserve address if not sent in counter-proposal', function (): void 
 
     $newDate = Carbon::now()->addDays(3)->toDateString();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => $newDate,
@@ -164,21 +164,21 @@ it('should allow multiple counter-proposals in sequence', function (): void {
         ]);
 
     // Doctor counter-proposes
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
         'scheduled_time' => '10:00',
     ])->assertOk()->assertJsonPath('data.proposed_by', 'doctor');
 
     // Receptor counter-proposes
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(6)->toDateString(),
         'scheduled_time' => '11:00',
     ])->assertOk()->assertJsonPath('data.proposed_by', 'receptor');
 
     // Doctor counter-proposes again
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(7)->toDateString(),
         'scheduled_time' => '12:00',
@@ -214,7 +214,7 @@ it('should return 403 when receptor tries to counter-propose own proposal', func
             'address_id'            => $address->id,
         ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -240,7 +240,7 @@ it('should return 403 when doctor tries to counter-propose own counter-proposal'
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -267,7 +267,7 @@ it('should return 403 when doctor tries to counter-propose another doctors appoi
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctorB->user);
+    actingAs($doctorB->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -295,7 +295,7 @@ it('should return 422 when scheduled_date is missing', function (): void {
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_time' => '10:00',
@@ -322,7 +322,7 @@ it('should return 422 when scheduled_time is missing', function (): void {
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -349,7 +349,7 @@ it('should return 422 when scheduled_date is in the past', function (): void {
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->subDays(1)->toDateString(),
@@ -377,7 +377,7 @@ it('should return 422 when scheduled_time has invalid format', function (): void
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -405,7 +405,7 @@ it('should return 422 when address_id does not exist', function (): void {
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -436,7 +436,7 @@ it('should return 422 when doctor uses another doctors address', function (): vo
             'address_id'            => $addressA->id,
         ]);
 
-    actingAs($doctorA->user);
+    actingAs($doctorA->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -467,7 +467,7 @@ it('should return 422 when trying to counter-propose confirmed appointment', fun
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -494,7 +494,7 @@ it('should return 422 when trying to counter-propose completed appointment', fun
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::now()->addDays(5)->toDateString(),
@@ -522,7 +522,7 @@ it('should ignore address_id when receptor counter-proposes', function (): void 
             'address_id'            => $address1->id,
         ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     // Receptor tries to set address_id but it should be ignored
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
@@ -554,7 +554,7 @@ it('should accept counter-proposal with today date', function (): void {
             'address_id'            => $address->id,
         ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-appointments/{$appointment->id}/counter-propose", [
         'scheduled_date' => Carbon::today()->toDateString(),

--- a/web/tests/Feature/Api/V1/MedicationAppointment/DoctorHistoryTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/DoctorHistoryTest.php
@@ -29,7 +29,7 @@ it('should return list of completed donations (doctor history)', function (): vo
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/doctor-history');
 
@@ -54,7 +54,7 @@ it('should return doctor history with correct structure including drug and recep
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/doctor-history');
 
@@ -99,7 +99,7 @@ it('should return doctor history with correct structure including drug and recep
 it('should return empty list when doctor has no completed donations', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     getJson('/api/v1/medication-appointments/doctor-history')
         ->assertOk()
@@ -146,7 +146,7 @@ it('should only return completed appointments, not proposed or confirmed', funct
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/doctor-history');
 
@@ -184,7 +184,7 @@ it('should only return own completed donations', function (): void {
         'address_id'            => $address2->id,
     ]);
 
-    actingAs($doctor1->user);
+    actingAs($doctor1->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/doctor-history');
 
@@ -224,7 +224,7 @@ it('should return history sorted by completion date (most recent first)', functi
         'updated_at'            => now()->subDays(2),
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/doctor-history');
 
@@ -243,7 +243,7 @@ it('should return 401 for unauthenticated users', function (): void {
 it('should return 403 when receptor tries to access doctor history', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-appointments/doctor-history')
         ->assertForbidden();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/HistoryTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/HistoryTest.php
@@ -29,7 +29,7 @@ it('should return list of completed appointments (medication history)', function
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/history');
 
@@ -54,7 +54,7 @@ it('should return history with correct structure including drug and doctor info'
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/history');
 
@@ -99,7 +99,7 @@ it('should return history with correct structure including drug and doctor info'
 it('should return empty list when receptor has no completed appointments', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-appointments/history')
         ->assertOk()
@@ -146,7 +146,7 @@ it('should only return completed appointments, not proposed or confirmed', funct
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/history');
 
@@ -183,7 +183,7 @@ it('should only return own completed appointments', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor1);
+    actingAs($receptor1, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/history');
 
@@ -223,7 +223,7 @@ it('should return history sorted by completion date (most recent first)', functi
         'updated_at'            => now()->subDays(2),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/history');
 
@@ -242,7 +242,7 @@ it('should return 401 for unauthenticated users', function (): void {
 it('should return 403 when doctor tries to access history', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     getJson('/api/v1/medication-appointments/history')
         ->assertForbidden();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/ListTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/ListTest.php
@@ -29,7 +29,7 @@ it('should return list of receptor appointments', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments');
 
@@ -53,7 +53,7 @@ it('should return appointments with correct structure', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments');
 
@@ -77,7 +77,7 @@ it('should return appointments with correct structure', function (): void {
 it('should return empty list when receptor has no appointments', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-appointments')
         ->assertOk()
@@ -112,7 +112,7 @@ it('should only return receptors own appointments', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor1);
+    actingAs($receptor1, 'sanctum');
 
     getJson('/api/v1/medication-appointments')
         ->assertOk()
@@ -146,7 +146,7 @@ it('should filter appointments by status', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-appointments?status=proposed')
         ->assertOk()
@@ -182,7 +182,7 @@ it('should return appointments sorted by scheduled date', function (): void {
         'scheduled_date'        => now()->addDays(2)->toDateString(),
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments');
 
@@ -201,7 +201,7 @@ it('should return 401 for unauthenticated users', function (): void {
 it('should return 403 when doctor tries to access receptor list', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     getJson('/api/v1/medication-appointments')
         ->assertForbidden();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/ReceivedTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/ReceivedTest.php
@@ -29,7 +29,7 @@ it('should return list of doctor received appointments', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/received');
 
@@ -53,7 +53,7 @@ it('should include receptor details in response', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-appointments/received');
 
@@ -99,7 +99,7 @@ it('should only return appointments for doctors offerings', function (): void {
         'address_id'            => $addressB->id,
     ]);
 
-    actingAs($doctorA->user);
+    actingAs($doctorA->user, 'sanctum');
 
     getJson('/api/v1/medication-appointments/received')
         ->assertOk()
@@ -133,7 +133,7 @@ it('should filter by status', function (): void {
         'address_id'            => $address->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     getJson('/api/v1/medication-appointments/received?status=proposed')
         ->assertOk()
@@ -150,7 +150,7 @@ it('should return 401 for unauthenticated users', function (): void {
 it('should return 403 when receptor tries to access doctor list', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-appointments/received')
         ->assertForbidden();

--- a/web/tests/Feature/Api/V1/MedicationAppointment/StoreTest.php
+++ b/web/tests/Feature/Api/V1/MedicationAppointment/StoreTest.php
@@ -26,7 +26,7 @@ it('should allow receptor to create appointment for confirmed request', function
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -57,7 +57,7 @@ it('should return 201 with appointment data including request and address', func
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -104,7 +104,7 @@ it('should use doctors first address automatically', function (): void {
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -127,7 +127,7 @@ it('should allow scheduling for today', function (): void {
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -143,7 +143,7 @@ it('should allow scheduling for today', function (): void {
 it('should return validation error when medication_request_id is missing', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'scheduled_date' => now()->addDays(3)->toDateString(),
@@ -156,7 +156,7 @@ it('should return validation error when medication_request_id is missing', funct
 it('should return validation error when medication_request_id does not exist', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => 99999,
@@ -174,7 +174,7 @@ it('should return validation error when scheduled_date is missing', function ():
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -195,7 +195,7 @@ it('should return validation error when scheduled_date is in the past', function
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -213,7 +213,7 @@ it('should return validation error when scheduled_time is missing', function ():
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -230,7 +230,7 @@ it('should return validation error when scheduled_time has invalid format', func
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -263,7 +263,7 @@ it('should return 403 forbidden when doctor tries to create appointment', functi
         ->confirmed()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -280,7 +280,7 @@ it('should return 403 when receptor tries to create appointment for another rece
         ->confirmed()
         ->create();
 
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -298,7 +298,7 @@ it('should return 422 when request is not confirmed (pending)', function (): voi
         ->pending()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -316,7 +316,7 @@ it('should return 422 when request is rejected', function (): void {
         ->rejected()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -344,7 +344,7 @@ it('should return 409 conflict when appointment already exists for request', fun
         'address_id'            => $address->id,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,
@@ -366,7 +366,7 @@ it('should return 422 when doctor has no registered addresses', function (): voi
         ->confirmed()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-appointments', [
         'medication_request_id' => $request->id,

--- a/web/tests/Feature/Api/V1/MedicationOffering/DeleteTest.php
+++ b/web/tests/Feature/Api/V1/MedicationOffering/DeleteTest.php
@@ -14,7 +14,7 @@ it('should delete the offering and return 204 No Content for the owner', functio
     $doctor   = Doctor::factory()->create();
     $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     deleteJson("/api/v1/medication-offerings/{$offering->id}")
         ->assertNoContent();
@@ -29,7 +29,7 @@ it('should return 403 Forbidden when trying to delete another doctor\'s offering
     $otherDoctor   = Doctor::factory()->create();
     $otherOffering = MedicationOffering::factory()->create(['doctor_id' => $otherDoctor->id]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     deleteJson("/api/v1/medication-offerings/{$otherOffering->id}")
         ->assertForbidden();
@@ -40,7 +40,7 @@ it('should return 403 Forbidden when trying to delete another doctor\'s offering
 it('should return 404 Not Found for a non-existent offering', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     deleteJson('/api/v1/medication-offerings/99999')
         ->assertNotFound();
@@ -57,7 +57,7 @@ it('should return 403 Forbidden for authenticated users who are not doctors', fu
     $user     = User::factory()->create();
     $offering = MedicationOffering::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     deleteJson("/api/v1/medication-offerings/{$offering->id}")
         ->assertForbidden();

--- a/web/tests/Feature/Api/V1/MedicationOffering/ListTest.php
+++ b/web/tests/Feature/Api/V1/MedicationOffering/ListTest.php
@@ -17,7 +17,7 @@ it('returns only the medication offerings belonging to the authenticated doctor'
     $myOfferings    = MedicationOffering::factory()->count(3)->create(['doctor_id' => $doctor->id]);
     $otherOfferings = MedicationOffering::factory()->count(2)->create(['doctor_id' => $otherDoctor->id]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     // ACT
     $response = getJson('/api/v1/medication-offerings');
@@ -46,7 +46,7 @@ it('should return 401 Unauthorized for unauthenticated users', function (): void
 it('should return 403 Forbidden for authenticated users who are not doctors', function (): void {
     $user = User::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     getJson(route('api.v1.medication-offerings.list'))
         ->assertForbidden();
@@ -55,7 +55,7 @@ it('should return 403 Forbidden for authenticated users who are not doctors', fu
 it('should return an empty paginated collection when the doctor has no offerings', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson(route('api.v1.medication-offerings.list'));
 
@@ -69,7 +69,7 @@ it('should respect the per_page pagination parameter', function (): void {
 
     MedicationOffering::factory()->count(5)->create(['doctor_id' => $doctor->id]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson(route('api.v1.medication-offerings.list') . '?per_page=2');
 
@@ -84,7 +84,7 @@ it('should return correct pagination metadata (total, current_page, etc.)', func
 
     MedicationOffering::factory()->count(7)->create(['doctor_id' => $doctor->id]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson(route('api.v1.medication-offerings.list') . '?per_page=3&page=2');
 
@@ -110,7 +110,7 @@ it('should optionally include related drug information when requested', function
         'doctor_id' => $doctor->id,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson(route('api.v1.medication-offerings.list') . '?include=drug');
 

--- a/web/tests/Feature/Api/V1/MedicationOffering/SearchTest.php
+++ b/web/tests/Feature/Api/V1/MedicationOffering/SearchTest.php
@@ -25,7 +25,7 @@ it('rejects invalid token with 401', function (): void {
 it('allows authenticated receptor to access search', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search?q=test')
         ->assertOk();
@@ -34,7 +34,7 @@ it('allows authenticated receptor to access search', function (): void {
 it('rejects authenticated doctor with 403', function (): void {
     $doctor = User::factory()->doctor()->create();
 
-    actingAs($doctor);
+    actingAs($doctor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search?q=aspirin')
         ->assertForbidden();
@@ -43,7 +43,7 @@ it('rejects authenticated doctor with 403', function (): void {
 it('rejects user without receptor role with 403', function (): void {
     $doctor = User::factory()->doctor()->create();
 
-    actingAs($doctor);
+    actingAs($doctor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search?q=aspirin')
         ->assertForbidden();
@@ -60,7 +60,7 @@ it('returns all offerings when q parameter is missing', function (): void {
         'quantity'  => 5,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search')
         ->assertOk()
@@ -78,7 +78,7 @@ it('returns all offerings when q parameter is empty', function (): void {
         'quantity'  => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search?q=')
         ->assertOk()
@@ -88,7 +88,7 @@ it('returns all offerings when q parameter is empty', function (): void {
 it('accepts valid search query', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search?q=aspirin')
         ->assertOk();
@@ -97,7 +97,7 @@ it('accepts valid search query', function (): void {
 it('accepts single character query', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-offerings/search?q=a')
         ->assertOk();
@@ -111,7 +111,7 @@ it('matches product_name', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=Aspirina');
 
@@ -128,7 +128,7 @@ it('matches substance', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=Ácido Acetilsalicílico');
 
@@ -145,7 +145,7 @@ it('matches partial product_name', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=Aspir');
 
@@ -161,7 +161,7 @@ it('matches partial substance', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=Dipirona');
 
@@ -177,7 +177,7 @@ it('search is case-insensitive for product_name', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=aspirina');
 
@@ -193,7 +193,7 @@ it('search is case-insensitive for substance', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=paracetamol');
 
@@ -209,7 +209,7 @@ it('returns multiple matching offerings', function (): void {
     MedicationOffering::factory()->create(['drug_id' => $drug1->id, 'quantity' => 10]);
     MedicationOffering::factory()->create(['drug_id' => $drug2->id, 'quantity' => 5]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=para');
 
@@ -225,7 +225,7 @@ it('includes offerings with quantity greater than zero', function (): void {
         'quantity' => 5,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=TestMed');
 
@@ -241,7 +241,7 @@ it('excludes offerings with quantity equal to zero', function (): void {
         'quantity' => 0,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=EmptyMed');
 
@@ -256,7 +256,7 @@ it('returns only available offerings when mixed availability', function (): void
     MedicationOffering::factory()->create(['drug_id' => $drug->id, 'quantity' => 10]);
     MedicationOffering::factory()->create(['drug_id' => $drug->id, 'quantity' => 0]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=MixedMed');
 
@@ -273,7 +273,7 @@ it('results contain required offering fields', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=FieldTest');
 
@@ -298,7 +298,7 @@ it('results contain nested drug information', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=DrugInfoTest');
 
@@ -328,7 +328,7 @@ it('results contain nested doctor information', function (): void {
         'quantity'  => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=DoctorInfoTest');
 
@@ -348,7 +348,7 @@ it('results contain nested doctor information', function (): void {
 it('returns empty array when no matches found', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=nonexistentmedication12345');
 
@@ -364,7 +364,7 @@ it('handles query with special characters', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=' . urlencode('vitamina B12'));
 
@@ -379,7 +379,7 @@ it('handles query with accented characters', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=Ácido');
 
@@ -395,7 +395,7 @@ it('handles query with numeric content', function (): void {
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=B12');
 
@@ -412,7 +412,7 @@ it('returns all matching offerings for large result set', function (): void {
         'quantity' => 5,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=CommonMed');
 
@@ -431,7 +431,7 @@ it('does not return offering when drug does not match query', function (): void 
         'quantity' => 10,
     ]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-offerings/search?q=Paracetamol');
 

--- a/web/tests/Feature/Api/V1/MedicationOffering/ShowTest.php
+++ b/web/tests/Feature/Api/V1/MedicationOffering/ShowTest.php
@@ -11,7 +11,7 @@ test('authenticated users can view their own medication offering', function (): 
         'doctor_id' => $user->doctor->id,
     ]);
 
-    $response = $this->actingAs($user)
+    $response = $this->actingAs($user, 'sanctum')
         ->getJson("/api/v1/medication-offerings/{$medicationOffering->id}");
 
     $response->assertSuccessful();
@@ -38,7 +38,7 @@ test('authenticated users cannot view other users medication offerings', functio
         'doctor_id' => $otherUser->doctor->id,
     ]);
 
-    $response = $this->actingAs($user)
+    $response = $this->actingAs($user, 'sanctum')
         ->getJson("/api/v1/medication-offerings/{$medicationOffering->id}");
 
     $response->assertForbidden();
@@ -55,7 +55,7 @@ test('unauthenticated users cannot view medication offerings', function (): void
 test('returns 404 for non-existent medication offering', function (): void {
     $user = User::factory()->doctor()->create();
 
-    $response = $this->actingAs($user)
+    $response = $this->actingAs($user, 'sanctum')
         ->getJson('/api/v1/medication-offerings/999999');
 
     $response->assertNotFound();

--- a/web/tests/Feature/Api/V1/MedicationOffering/StoreTest.php
+++ b/web/tests/Feature/Api/V1/MedicationOffering/StoreTest.php
@@ -31,7 +31,7 @@ it('should be accessible via POST /api/v1/medication-offerings', function (): vo
         'quantity'   => 20,
     ];
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
     postJson('/api/v1/medication-offerings', $payload1)
         ->assertCreated();
 
@@ -52,7 +52,7 @@ it('should return 201, create the offering and associate it with the authenticat
         'quantity'   => 10,
     ];
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = postJson(route('api.v1.medication-offerings.post'), $payload);
 
@@ -89,7 +89,7 @@ it('should return the correct Content-Type header', function (): void {
         'quantity'   => 1,
     ];
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = postJson(route('api.v1.medication-offerings.post'), $payload);
     $response->assertCreated();
@@ -100,7 +100,7 @@ it('should return the correct Content-Type header', function (): void {
 
 it('should return a validation error if required fields are missing', function (): void {
     $user = User::factory()->doctor()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $response = postJson(route('api.v1.medication-offerings.post'), []);
     $response->assertUnprocessable()
@@ -116,7 +116,7 @@ it('should return a validation error if required fields are missing', function (
 
 it('should return a validation error if drug_id does not exist', function (): void {
     $user = User::factory()->doctor()->create();
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $payload = [
         'drug_id'    => 9999999, // non-existent
@@ -135,7 +135,7 @@ it('should return a validation error for invalid data types or formats', functio
     $user = User::factory()->doctor()->create();
     $drug = Drug::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $payload = [
         'drug_id'    => 'not-an-integer',
@@ -160,7 +160,7 @@ it('should return a validation error if quantity is not a positive integer', fun
     $user = User::factory()->doctor()->create();
     $drug = Drug::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     // zero
     $payloadZero = [
@@ -189,7 +189,7 @@ it('should return a validation error if expiration_date is in the past', functio
     $user = User::factory()->doctor()->create();
     $drug = Drug::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $payload = [
         'drug_id'    => $drug->id,
@@ -222,7 +222,7 @@ it('should return 403 forbidden if an authenticated user is not a doctor', funct
     $user = User::factory()->create(); // regular user (not doctor)
     $drug = Drug::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     $payload = [
         'drug_id'    => $drug->id,

--- a/web/tests/Feature/Api/V1/MedicationOffering/UpdateTest.php
+++ b/web/tests/Feature/Api/V1/MedicationOffering/UpdateTest.php
@@ -30,7 +30,7 @@ it('updates the medication offering when requested by the owning doctor', functi
         'quantity'   => 20,
     ];
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = putJson(
         '/api/v1/medication-offerings/' . $offering->id,
@@ -66,7 +66,7 @@ it('allows partial updates (only provided fields are changed)', function (): voi
         'quantity'   => 10,
     ]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $payload = ['quantity' => 1];
 
@@ -88,7 +88,7 @@ it('returns a validation error for various invalid data payloads', function (arr
     $doctor   = Doctor::factory()->create();
     $offering = MedicationOffering::factory()->create(['doctor_id' => $doctor->id]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $payload = array_merge([
         'lot_number' => 'VALID-LOT',
@@ -123,7 +123,7 @@ it('returns 403 if an authenticated user is not a doctor', function (): void {
     $user     = User::factory()->create();
     $offering = MedicationOffering::factory()->create();
 
-    actingAs($user);
+    actingAs($user, 'sanctum');
 
     putJson(
         route('api.v1.medication-offerings.put', ['medicationOffering' => $offering->id]),
@@ -140,7 +140,7 @@ it('returns 403 if an authenticated doctor is not the owner of the offering', fu
         'quantity'  => 5,
     ]);
 
-    actingAs($otherDoctor->user);
+    actingAs($otherDoctor->user, 'sanctum');
 
     putJson(
         route('api.v1.medication-offerings.put', ['medicationOffering' => $offering->id]),

--- a/web/tests/Feature/Api/V1/MedicationRequest/ConfirmTest.php
+++ b/web/tests/Feature/Api/V1/MedicationRequest/ConfirmTest.php
@@ -23,7 +23,7 @@ it('should allow doctor to confirm a pending request for their offering', functi
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = patchJson("/api/v1/medication-requests/{$request->id}/confirm");
 
@@ -45,7 +45,7 @@ it('should keep offering status as reserved after confirmation', function (): vo
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/confirm")
         ->assertOk();
@@ -65,7 +65,7 @@ it('should return updated request data after confirmation', function (): void {
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = patchJson("/api/v1/medication-requests/{$request->id}/confirm");
 
@@ -104,7 +104,7 @@ it('should return 403 forbidden when receptor tries to confirm a request', funct
         ->pending()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/confirm")
         ->assertForbidden();
@@ -122,7 +122,7 @@ it('should return 403 forbidden when doctor tries to confirm another doctor\'s r
         ->pending()
         ->create();
 
-    actingAs($doctorA->user);
+    actingAs($doctorA->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/confirm")
         ->assertForbidden();
@@ -141,7 +141,7 @@ it('should return 422 when trying to confirm an already confirmed request', func
         ->confirmed()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/confirm")
         ->assertStatus(422)
@@ -161,7 +161,7 @@ it('should return 422 when trying to confirm a rejected request', function (): v
         ->rejected()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/confirm")
         ->assertStatus(422)
@@ -175,7 +175,7 @@ it('should return 422 when trying to confirm a rejected request', function (): v
 it('should return 404 for non-existent request', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson('/api/v1/medication-requests/99999/confirm')
         ->assertNotFound();

--- a/web/tests/Feature/Api/V1/MedicationRequest/ListTest.php
+++ b/web/tests/Feature/Api/V1/MedicationRequest/ListTest.php
@@ -22,7 +22,7 @@ it('should allow a receptor to list their own requests', function (): void {
         ->pending()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 
@@ -44,7 +44,7 @@ it('should allow a receptor to list their own requests', function (): void {
 it('should return empty array when receptor has no requests', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 
@@ -62,7 +62,7 @@ it('should include offering and drug details in response', function (): void {
         ->pending()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 
@@ -106,7 +106,7 @@ it('should return requests ordered by created_at descending', function (): void 
         ->forOffering($offering2)
         ->create(['created_at' => now()]);
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 
@@ -134,7 +134,7 @@ it('should only return the authenticated receptor\'s requests', function (): voi
         ->forOffering($offering2)
         ->create();
 
-    actingAs($receptor1);
+    actingAs($receptor1, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 
@@ -152,7 +152,7 @@ it('should return 401 unauthorized for unauthenticated users', function (): void
 it('should return empty array when doctor tries to list (no requests as receptor)', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 
@@ -172,7 +172,7 @@ it('should not allow receptor A to see receptor B\'s requests', function (): voi
         ->forOffering($offering)
         ->create();
 
-    actingAs($receptorA);
+    actingAs($receptorA, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests');
 

--- a/web/tests/Feature/Api/V1/MedicationRequest/ReceivedTest.php
+++ b/web/tests/Feature/Api/V1/MedicationRequest/ReceivedTest.php
@@ -23,7 +23,7 @@ it('should allow a doctor to list requests for their offerings', function (): vo
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 
@@ -46,7 +46,7 @@ it('should allow a doctor to list requests for their offerings', function (): vo
 it('should return empty array when doctor has no received requests', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 
@@ -65,7 +65,7 @@ it('should include receptor details in response', function (): void {
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 
@@ -95,7 +95,7 @@ it('should include offering and drug details in response', function (): void {
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 
@@ -129,7 +129,7 @@ it('should return requests ordered by created_at descending', function (): void 
         ->forOffering($offering2)
         ->create(['created_at' => now()]);
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 
@@ -159,7 +159,7 @@ it('should filter requests by status=pending', function (): void {
         ->confirmed()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received?status=pending');
 
@@ -186,7 +186,7 @@ it('should filter requests by status=confirmed', function (): void {
         ->confirmed()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received?status=confirmed');
 
@@ -213,7 +213,7 @@ it('should filter requests by status=rejected', function (): void {
         ->rejected()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received?status=rejected');
 
@@ -233,7 +233,7 @@ it('should return all statuses when no filter is provided', function (): void {
     MedicationRequest::factory()->forReceptor($receptor)->forOffering($offering2)->confirmed()->create();
     MedicationRequest::factory()->forReceptor($receptor)->forOffering($offering3)->rejected()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 
@@ -251,7 +251,7 @@ it('should return 401 unauthorized for unauthenticated users', function (): void
 it('should return 403 forbidden when receptor tries to access received endpoint', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     getJson('/api/v1/medication-requests/received')
         ->assertForbidden();
@@ -271,7 +271,7 @@ it('should not allow doctor A to see doctor B\'s received requests', function ()
         ->pending()
         ->create();
 
-    actingAs($doctorA->user);
+    actingAs($doctorA->user, 'sanctum');
 
     $response = getJson('/api/v1/medication-requests/received');
 

--- a/web/tests/Feature/Api/V1/MedicationRequest/RejectTest.php
+++ b/web/tests/Feature/Api/V1/MedicationRequest/RejectTest.php
@@ -24,7 +24,7 @@ it('should allow doctor to reject a pending request for their offering', functio
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = patchJson("/api/v1/medication-requests/{$request->id}/reject");
 
@@ -46,7 +46,7 @@ it('should return offering status to available after rejection', function (): vo
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/reject")
         ->assertOk();
@@ -66,7 +66,7 @@ it('should return updated request data after rejection', function (): void {
         ->pending()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     $response = patchJson("/api/v1/medication-requests/{$request->id}/reject");
 
@@ -98,12 +98,12 @@ it('should allow another receptor to request after rejection', function (): void
         ->create();
 
     // Doctor rejects
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
     patchJson("/api/v1/medication-requests/{$request->id}/reject")
         ->assertOk();
 
     // Another receptor can now request
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
     ])->assertCreated();
@@ -132,7 +132,7 @@ it('should return 403 forbidden when receptor tries to reject a request', functi
         ->pending()
         ->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/reject")
         ->assertForbidden();
@@ -150,7 +150,7 @@ it('should return 403 forbidden when doctor tries to reject another doctor\'s re
         ->pending()
         ->create();
 
-    actingAs($doctorA->user);
+    actingAs($doctorA->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/reject")
         ->assertForbidden();
@@ -169,7 +169,7 @@ it('should return 422 when trying to reject an already confirmed request', funct
         ->confirmed()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/reject")
         ->assertStatus(422)
@@ -189,7 +189,7 @@ it('should return 422 when trying to reject an already rejected request', functi
         ->rejected()
         ->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson("/api/v1/medication-requests/{$request->id}/reject")
         ->assertStatus(422)
@@ -203,7 +203,7 @@ it('should return 422 when trying to reject an already rejected request', functi
 it('should return 404 for non-existent request', function (): void {
     $doctor = Doctor::factory()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     patchJson('/api/v1/medication-requests/99999/reject')
         ->assertNotFound();

--- a/web/tests/Feature/Api/V1/MedicationRequest/StoreTest.php
+++ b/web/tests/Feature/Api/V1/MedicationRequest/StoreTest.php
@@ -19,7 +19,7 @@ it('should allow a receptor to create a request for an available offering', func
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -38,7 +38,7 @@ it('should return 201 with request data including offering details', function ()
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -69,7 +69,7 @@ it('should change the offering status to reserved after request creation', funct
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -83,7 +83,7 @@ it('should return the correct Content-Type header', function (): void {
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     $response = postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -99,7 +99,7 @@ it('should return the correct Content-Type header', function (): void {
 it('should return validation error when medication_offering_id is missing', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [])
         ->assertUnprocessable()
@@ -109,7 +109,7 @@ it('should return validation error when medication_offering_id is missing', func
 it('should return validation error when medication_offering_id does not exist', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => 99999,
@@ -121,7 +121,7 @@ it('should return validation error when medication_offering_id does not exist', 
 it('should return validation error when medication_offering_id is not an integer', function (): void {
     $receptor = User::factory()->receptor()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => 'not-an-integer',
@@ -144,7 +144,7 @@ it('should return 403 forbidden when a doctor tries to create a request', functi
     $doctor   = Doctor::factory()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($doctor->user);
+    actingAs($doctor->user, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -157,7 +157,7 @@ it('should return 409 conflict when requesting an already reserved offering', fu
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->reserved()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -172,7 +172,7 @@ it('should return 409 conflict when same receptor tries to request same offering
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     // First request succeeds
     postJson('/api/v1/medication-requests', [
@@ -193,7 +193,7 @@ it('should allow requesting an offering that was previously rejected', function 
     $offering  = MedicationOffering::factory()->available()->create();
 
     // First receptor requests
-    actingAs($receptor1);
+    actingAs($receptor1, 'sanctum');
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
     ])->assertCreated();
@@ -211,7 +211,7 @@ it('should allow requesting an offering that was previously rejected', function 
     expect($offering->status)->toBe('available');
 
     // Second receptor can now request
-    actingAs($receptor2);
+    actingAs($receptor2, 'sanctum');
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
     ])->assertCreated();
@@ -227,7 +227,7 @@ it('should dispatch NotifyDoctorNewRequestJob when creating a request', function
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,
@@ -242,7 +242,7 @@ it('should dispatch notification with correct request id', function (): void {
     $receptor = User::factory()->receptor()->create();
     $offering = MedicationOffering::factory()->available()->create();
 
-    actingAs($receptor);
+    actingAs($receptor, 'sanctum');
 
     postJson('/api/v1/medication-requests', [
         'medication_offering_id' => $offering->id,

--- a/web/tests/Feature/Middleware/EnsureUserIsApprovedTest.php
+++ b/web/tests/Feature/Middleware/EnsureUserIsApprovedTest.php
@@ -8,7 +8,7 @@ describe('EnsureUserIsApproved Middleware', function (): void {
     it('allows approved users to access protected routes', function (): void {
         $user = User::factory()->receptor()->create();
 
-        $this->actingAs($user)
+        $this->actingAs($user, 'sanctum')
             ->getJson(route('api.v1.drugs.list'))
             ->assertStatus(200);
     });
@@ -16,7 +16,7 @@ describe('EnsureUserIsApproved Middleware', function (): void {
     it('blocks pending users from accessing protected routes', function (): void {
         $user = User::factory()->receptor()->pending()->create();
 
-        $this->actingAs($user)
+        $this->actingAs($user, 'sanctum')
             ->getJson(route('api.v1.drugs.list'))
             ->assertStatus(403)
             ->assertJson([
@@ -28,7 +28,7 @@ describe('EnsureUserIsApproved Middleware', function (): void {
     it('blocks rejected users from accessing protected routes', function (): void {
         $user = User::factory()->receptor()->rejected()->create();
 
-        $this->actingAs($user)
+        $this->actingAs($user, 'sanctum')
             ->getJson(route('api.v1.drugs.list'))
             ->assertStatus(403)
             ->assertJson([

--- a/web/tests/Feature/Security/LgpdDataProtectionTest.php
+++ b/web/tests/Feature/Security/LgpdDataProtectionTest.php
@@ -145,7 +145,7 @@ describe('API Data Masking', function (): void {
             'status'                 => 'pending',
         ]);
 
-        $response = actingAs($doctor)
+        $response = actingAs($doctor, 'sanctum')
             ->getJson(route('api.v1.medication-requests.received'));
 
         $response->assertOk();
@@ -175,7 +175,7 @@ describe('API Data Masking', function (): void {
             'status'                 => 'pending',
         ]);
 
-        $response = actingAs($doctor)
+        $response = actingAs($doctor, 'sanctum')
             ->getJson(route('api.v1.medication-requests.received'));
 
         $response->assertOk();
@@ -206,7 +206,7 @@ describe('API Data Masking', function (): void {
             'status'                 => 'confirmed',
         ]);
 
-        $response = actingAs($doctor)
+        $response = actingAs($doctor, 'sanctum')
             ->getJson(route('api.v1.medication-requests.received'));
 
         $response->assertOk();

--- a/web/tests/TestCase.php
+++ b/web/tests/TestCase.php
@@ -4,9 +4,57 @@ declare(strict_types = 1);
 
 namespace Tests;
 
+use App\Enums\TokenAbility;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Laravel\Sanctum\Sanctum;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * Set the currently logged in user for the application.
+     *
+     * When guard is 'sanctum', uses Sanctum::actingAs with 'access' ability by default.
+     * This ensures tests properly simulate real API authentication with token abilities.
+     *
+     * @param  array<string>  $abilities
+     */
+    public function actingAs(Authenticatable $user, mixed $guard = null, array $abilities = []): static
+    {
+        // Only use Sanctum for explicit 'sanctum' guard
+        if ($guard === 'sanctum') {
+            if (empty($abilities)) {
+                $abilities = [TokenAbility::Access->value];
+            }
+
+            Sanctum::actingAs($user, $abilities);
+
+            return $this;
+        }
+
+        return parent::actingAs($user, $guard);
+    }
+
+    /**
+     * Authenticate as user with access token ability (for API tests).
+     */
+    public function actingAsApiUser(Authenticatable $user): static
+    {
+        Sanctum::actingAs($user, [TokenAbility::Access->value]);
+
+        return $this;
+    }
+
+    /**
+     * Authenticate as user with refresh token ability.
+     *
+     * @param  array<string>  $additionalAbilities
+     */
+    public function actingAsWithRefreshToken(Authenticatable $user, array $additionalAbilities = []): static
+    {
+        $abilities = array_merge([TokenAbility::Refresh->value], $additionalAbilities);
+        Sanctum::actingAs($user, $abilities);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## Summary

Resolve a vulnerabilidade de segurança identificada na issue #80 onde tokens de autenticação não tinham expiração (`'expiration' => null`). 

Implementa o padrão industry-standard de refresh tokens:
- **Access token**: 1 hora de validade (ability: `access`)
- **Refresh token**: 30 dias de validade (ability: `refresh`)

### Principais mudanças

- `CreateTokenPairAction`: Cria par de tokens com abilities e expirações corretas
- `RefreshTokenAction`: Renova access token usando refresh token válido
- `LogoutAction`: Revoga todos os tokens do device específico
- `RefreshController` + `LogoutController`: Novos endpoints de autenticação
- `LoginResource`: Retorna estrutura completa com tokens e tempos de expiração
- `LoginRequest`: Aceita `device_name` opcional para identificação de dispositivos

### Novos endpoints

| Método | Endpoint | Descrição | Middleware |
|--------|----------|-----------|------------|
| POST | `/api/v1/auth/refresh` | Renova access token | `auth:sanctum`, `abilities:refresh` |
| POST | `/api/v1/auth/logout` | Revoga tokens do device | `auth:sanctum`, `abilities:access` |

### Estrutura de resposta do login

```json
{
  "data": {
    "user": { ... },
    "access_token": "...",
    "refresh_token": "...",
    "expires_in": 3600,
    "refresh_expires_in": 2592000
  },
  "message": "Login realizado com sucesso"
}
```

## Notas de segurança

- Rate limiting no login (5 tentativas/minuto por email+IP)
- Verificação de status do usuário no refresh (rejeita pending/rejected)
- Isolamento de tokens por device no logout
- Sanctum valida expiração automaticamente via Guard

## Test plan

- [x] Testes de integração para login com token pair
- [x] Testes de refresh token (happy path + edge cases)
- [x] Testes de logout (device isolation)
- [x] Testes de expiração de tokens
- [x] Testes de validação de abilities
- [x] **518 testes passando** (incluindo 45 novos testes de auth)

## Checklist

- [x] PHPStan passou sem erros
- [x] Pint formatou o código
- [x] Todos os testes passando
- [x] Segue padrões do projeto (Actions, Controllers invokable)
- [x] Documentação inline nos métodos

Closes #80