### PR TITLE
feat(mobile): add all 27 Brazilian states to UF selects

### DIFF
--- a/mobile/__tests__/constants/BrazilianStates.test.ts
+++ b/mobile/__tests__/constants/BrazilianStates.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for BRAZILIAN_STATES constant
+ *
+ * Ensures all 27 Brazilian states are present, correctly ordered,
+ * and have the expected structure.
+ */
+
+import { BRAZILIAN_STATES } from '@/constants/BrazilianStates';
+
+describe('BRAZILIAN_STATES', () => {
+  describe('completeness', () => {
+    it('should have exactly 27 states', () => {
+      expect(BRAZILIAN_STATES).toHaveLength(27);
+    });
+
+    it('should include all Brazilian states', () => {
+      const expectedStates = [
+        'AC',
+        'AL',
+        'AM',
+        'AP',
+        'BA',
+        'CE',
+        'DF',
+        'ES',
+        'GO',
+        'MA',
+        'MG',
+        'MS',
+        'MT',
+        'PA',
+        'PB',
+        'PE',
+        'PI',
+        'PR',
+        'RJ',
+        'RN',
+        'RO',
+        'RR',
+        'RS',
+        'SC',
+        'SE',
+        'SP',
+        'TO',
+      ];
+
+      const stateValues = BRAZILIAN_STATES.map((s) => s.value);
+      expect(stateValues).toEqual(expect.arrayContaining(expectedStates));
+      expect(expectedStates).toEqual(expect.arrayContaining(stateValues));
+    });
+  });
+
+  describe('ordering', () => {
+    it('should be sorted alphabetically by value', () => {
+      const values = BRAZILIAN_STATES.map((s) => s.value);
+      const sortedValues = [...values].sort();
+      expect(values).toEqual(sortedValues);
+    });
+
+    it('should start with AC (Acre)', () => {
+      expect(BRAZILIAN_STATES[0].value).toBe('AC');
+    });
+
+    it('should end with TO (Tocantins)', () => {
+      expect(BRAZILIAN_STATES[26].value).toBe('TO');
+    });
+  });
+
+  describe('structure', () => {
+    it('should have label and value properties for each state', () => {
+      BRAZILIAN_STATES.forEach((state) => {
+        expect(state).toHaveProperty('label');
+        expect(state).toHaveProperty('value');
+      });
+    });
+
+    it('should have label equal to value (state abbreviation)', () => {
+      BRAZILIAN_STATES.forEach((state) => {
+        expect(state.label).toBe(state.value);
+      });
+    });
+
+    it('should have 2-character uppercase values', () => {
+      BRAZILIAN_STATES.forEach((state) => {
+        expect(state.value).toMatch(/^[A-Z]{2}$/);
+      });
+    });
+  });
+});

--- a/mobile/constants/BrazilianStates.ts
+++ b/mobile/constants/BrazilianStates.ts
@@ -1,0 +1,34 @@
+interface BrazilianState {
+  readonly label: string;
+  readonly value: string;
+}
+
+export const BRAZILIAN_STATES: readonly BrazilianState[] = [
+  { label: 'AC', value: 'AC' },
+  { label: 'AL', value: 'AL' },
+  { label: 'AM', value: 'AM' },
+  { label: 'AP', value: 'AP' },
+  { label: 'BA', value: 'BA' },
+  { label: 'CE', value: 'CE' },
+  { label: 'DF', value: 'DF' },
+  { label: 'ES', value: 'ES' },
+  { label: 'GO', value: 'GO' },
+  { label: 'MA', value: 'MA' },
+  { label: 'MG', value: 'MG' },
+  { label: 'MS', value: 'MS' },
+  { label: 'MT', value: 'MT' },
+  { label: 'PA', value: 'PA' },
+  { label: 'PB', value: 'PB' },
+  { label: 'PE', value: 'PE' },
+  { label: 'PI', value: 'PI' },
+  { label: 'PR', value: 'PR' },
+  { label: 'RJ', value: 'RJ' },
+  { label: 'RN', value: 'RN' },
+  { label: 'RO', value: 'RO' },
+  { label: 'RR', value: 'RR' },
+  { label: 'RS', value: 'RS' },
+  { label: 'SC', value: 'SC' },
+  { label: 'SE', value: 'SE' },
+  { label: 'SP', value: 'SP' },
+  { label: 'TO', value: 'TO' },
+];

--- a/mobile/screens/DoctorRegistration/steps/DoctorAddressStep/index.tsx
+++ b/mobile/screens/DoctorRegistration/steps/DoctorAddressStep/index.tsx
@@ -10,6 +10,7 @@ import { InputRow } from '@/components/InputRow';
 import { Select, SelectItem } from '@/components/Select';
 import { Picker } from '@react-native-picker/picker';
 import { DoctorRegistrationFormData } from '@/stores/doctorRegistrationFormStore';
+import { BRAZILIAN_STATES } from '@/constants/BrazilianStates';
 import { z } from 'zod';
 import { useFeatureForm } from '@/hooks/useFeatureForm';
 
@@ -125,11 +126,9 @@ export function DoctorAddressStep({ onSubmit }: DoctorAddressStepProps) {
             containerStyle={{ flex: 1 }}
             nextRef={cityRef}
           >
-            <SelectItem label="AC" value="AC" />
-            <SelectItem label="AL" value="AL" />
-            <SelectItem label="AP" value="AP" />
-            <SelectItem label="AM" value="AM" />
-            <SelectItem label="BA" value="BA" />
+            {BRAZILIAN_STATES.map((state) => (
+              <SelectItem key={state.value} label={state.label} value={state.value} />
+            ))}
           </Select>
           <Select
             ref={cityRef}

--- a/mobile/screens/DoctorRegistration/steps/DoctorPersonalDataStep/index.tsx
+++ b/mobile/screens/DoctorRegistration/steps/DoctorPersonalDataStep/index.tsx
@@ -10,6 +10,7 @@ import { InputRow } from '@/components/InputRow';
 import { Select, SelectItem } from '@/components/Select';
 import { Picker } from '@react-native-picker/picker';
 import { DoctorRegistrationFormData } from '@/stores/doctorRegistrationFormStore';
+import { BRAZILIAN_STATES } from '@/constants/BrazilianStates';
 import { z } from 'zod';
 import { useFeatureForm } from '@/hooks/useFeatureForm';
 
@@ -123,11 +124,9 @@ export function DoctorPersonalDataStep({ onSubmit }: DoctorPersonalDataStepProps
             containerStyle={{ flex: 1 }}
             nextRef={dddRef}
           >
-            <SelectItem label="AC" value="AC" />
-            <SelectItem label="AL" value="AL" />
-            <SelectItem label="AP" value="AP" />
-            <SelectItem label="AM" value="AM" />
-            <SelectItem label="BA" value="BA" />
+            {BRAZILIAN_STATES.map((state) => (
+              <SelectItem key={state.value} label={state.label} value={state.value} />
+            ))}
           </Select>
         </InputRow>
         <InputRow>


### PR DESCRIPTION
## Summary

- Create `BRAZILIAN_STATES` constant with all 27 states sorted alphabetically
- Replace hardcoded 5 states with dynamic list in CRM UF select
- Replace hardcoded 5 states with dynamic list in address UF select

## Problem

81% of Brazilian doctors could not register because their states were not available in the dropdown (only AC, AL, AP, AM, BA were present).

## Solution

Created a centralized constant with all 27 Brazilian states and used it in both registration forms:
- `DoctorPersonalDataStep` (CRM UF)
- `DoctorAddressStep` (Address UF)

## Test Plan

- [x] Unit tests for `BRAZILIAN_STATES` constant (8 tests)
  - Completeness: 27 states present
  - Ordering: alphabetically sorted
  - Structure: label/value format
- [ ] Manual test: Register as doctor from SP
- [ ] Manual test: Register as doctor from RJ

## How to Test Manually

1. Start mobile app: `cd mobile && npm start`
2. Go to doctor registration flow
3. Verify UF dropdown shows all 27 states
4. Select a state (e.g., SP) and continue registration

Closes #82