### PR TITLE
perf: add eager loading to Filament list pages

### DIFF
--- a/web/app/Filament/Resources/ActivityLogResource/Pages/ListActivityLogs.php
+++ b/web/app/Filament/Resources/ActivityLogResource/Pages/ListActivityLogs.php
@@ -6,13 +6,27 @@ namespace App\Filament\Resources\ActivityLogResource\Pages;
 
 use App\Filament\Resources\ActivityLogResource;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
+use Override;
+use Spatie\Activitylog\Models\Activity;
 
 class ListActivityLogs extends ListRecords
 {
     protected static string $resource = ActivityLogResource::class;
 
+    #[Override]
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    /**
+     * @return Builder<Activity>
+     */
+    #[Override]
+    protected function getTableQuery(): Builder
+    {
+        return parent::getTableQuery()
+            ->with(['causer']);
     }
 }

--- a/web/app/Filament/Resources/MedicationAppointmentResource/Pages/ListMedicationAppointments.php
+++ b/web/app/Filament/Resources/MedicationAppointmentResource/Pages/ListMedicationAppointments.php
@@ -5,7 +5,9 @@ declare(strict_types = 1);
 namespace App\Filament\Resources\MedicationAppointmentResource\Pages;
 
 use App\Filament\Resources\MedicationAppointmentResource;
+use App\Models\MedicationAppointment;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 use Override;
 
 class ListMedicationAppointments extends ListRecords
@@ -16,5 +18,19 @@ class ListMedicationAppointments extends ListRecords
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    /**
+     * @return Builder<MedicationAppointment>
+     */
+    #[Override]
+    protected function getTableQuery(): Builder
+    {
+        return parent::getTableQuery()
+            ->with([
+                'medicationRequest.receptor',
+                'medicationRequest.medicationOffering.drug',
+                'medicationRequest.medicationOffering.doctor.user',
+            ]);
     }
 }

--- a/web/app/Filament/Resources/MedicationOfferingResource/Pages/ListMedicationOfferings.php
+++ b/web/app/Filament/Resources/MedicationOfferingResource/Pages/ListMedicationOfferings.php
@@ -5,7 +5,9 @@ declare(strict_types = 1);
 namespace App\Filament\Resources\MedicationOfferingResource\Pages;
 
 use App\Filament\Resources\MedicationOfferingResource;
+use App\Models\MedicationOffering;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 use Override;
 
 class ListMedicationOfferings extends ListRecords
@@ -16,5 +18,15 @@ class ListMedicationOfferings extends ListRecords
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    /**
+     * @return Builder<MedicationOffering>
+     */
+    #[Override]
+    protected function getTableQuery(): Builder
+    {
+        return parent::getTableQuery()
+            ->with(['drug', 'doctor.user']);
     }
 }

--- a/web/app/Filament/Resources/MedicationRequestResource/Pages/ListMedicationRequests.php
+++ b/web/app/Filament/Resources/MedicationRequestResource/Pages/ListMedicationRequests.php
@@ -5,7 +5,9 @@ declare(strict_types = 1);
 namespace App\Filament\Resources\MedicationRequestResource\Pages;
 
 use App\Filament\Resources\MedicationRequestResource;
+use App\Models\MedicationRequest;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 use Override;
 
 class ListMedicationRequests extends ListRecords
@@ -16,5 +18,19 @@ class ListMedicationRequests extends ListRecords
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    /**
+     * @return Builder<MedicationRequest>
+     */
+    #[Override]
+    protected function getTableQuery(): Builder
+    {
+        return parent::getTableQuery()
+            ->with([
+                'receptor',
+                'medicationOffering.drug',
+                'medicationOffering.doctor.user',
+            ]);
     }
 }


### PR DESCRIPTION
## Summary

- Add `getTableQuery()` method with eager loading to ListMedicationOfferings
- Add `getTableQuery()` method with eager loading to ListMedicationRequests
- Add `getTableQuery()` method with eager loading to ListMedicationAppointments

## Problem

Filament Admin panel listings were causing N+1 query issues:
- MedicationOfferingResource: ~100 extra queries
- MedicationRequestResource: ~200 extra queries
- MedicationAppointmentResource: ~250 extra queries

This resulted in 1-4 seconds of extra load time per page.

## Solution

Override `getTableQuery()` in each list page to add eager loading for the relationships used in table columns.

## Test Plan

- [x] PHPStan passes
- [x] All 523 tests pass
- [ ] Verify with Laravel Debugbar that queries dropped from 300+ to <10 per page
- [ ] Test that list pages render correctly (filters, sorting, search)

Closes #84