### PR TITLE
feat(mobile): add accessibility support to main components

### DIFF
--- a/mobile/components/AddressSelector/index.tsx
+++ b/mobile/components/AddressSelector/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, memo } from 'react';
 import { View, Pressable, Text } from 'react-native';
 import { Address } from '@/types/medicationAppointment';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface AddressItemProps {
   address: Address;
@@ -15,7 +16,11 @@ const AddressItem = memo(function AddressItem({ address, isSelected, onSelect }:
   }, [address.id, onSelect]);
 
   return (
-    <Pressable style={[styles.option, isSelected && styles.optionSelected]} onPress={handlePress}>
+    <Pressable
+      style={[styles.option, isSelected && styles.optionSelected]}
+      onPress={handlePress}
+      {...a11y.radioButton(address.location_name, isSelected)}
+    >
       <View style={[styles.radioButton, isSelected && styles.radioButtonSelected]}>
         {isSelected && <View style={styles.radioButtonInner} />}
       </View>

--- a/mobile/components/AppointmentStatusBadge/index.tsx
+++ b/mobile/components/AppointmentStatusBadge/index.tsx
@@ -5,6 +5,7 @@ import {
   APPOINTMENT_STATUS_LABELS,
   APPOINTMENT_STATUS_COLORS,
 } from '@/types/medicationAppointment';
+import { a11y } from '@/utils/accessibility';
 
 interface AppointmentStatusBadgeProps {
   status: MedicationAppointmentStatus;
@@ -15,7 +16,7 @@ export function AppointmentStatusBadge({ status }: AppointmentStatusBadgeProps) 
   const label = APPOINTMENT_STATUS_LABELS[status] || status;
 
   return (
-    <View style={[styles.badge, { backgroundColor }]}>
+    <View style={[styles.badge, { backgroundColor }]} {...a11y.badge(label)}>
       <Text style={styles.text}>{label}</Text>
     </View>
   );

--- a/mobile/components/ArrowBackButton/index.tsx
+++ b/mobile/components/ArrowBackButton/index.tsx
@@ -1,6 +1,7 @@
 import { Pressable, PressableProps, StyleProp, ViewStyle } from 'react-native';
 import { styles } from './styles';
 import { Ionicons } from '@expo/vector-icons';
+import { a11y } from '@/utils/accessibility';
 
 type ArrowBackButtonProps = Omit<PressableProps, 'style'> & {
   style?: StyleProp<ViewStyle>;
@@ -8,7 +9,7 @@ type ArrowBackButtonProps = Omit<PressableProps, 'style'> & {
 
 export default function ArrowBackButton({ style, ...props }: ArrowBackButtonProps) {
   return (
-    <Pressable {...props} style={[styles.arrowBackButton, style]}>
+    <Pressable {...a11y.backButton()} {...props} style={[styles.arrowBackButton, style]}>
       {({ pressed }) => (
         <Ionicons
           name="arrow-back"

--- a/mobile/components/CounterProposeModal/index.tsx
+++ b/mobile/components/CounterProposeModal/index.tsx
@@ -9,6 +9,7 @@ import { DateInput } from '@/components/DateInput';
 import { TimeInput } from '@/components/TimeInput';
 import { AddressSelector } from '@/components/AddressSelector';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface CounterProposeModalProps {
   visible: boolean;
@@ -81,7 +82,7 @@ export const CounterProposeModal = memo(function CounterProposeModal({
         <View style={styles.modalContainer}>
           <View style={styles.header}>
             <Text style={styles.title}>Contrapropor Horário</Text>
-            <Pressable onPress={onClose} style={styles.closeButton}>
+            <Pressable onPress={onClose} style={styles.closeButton} {...a11y.closeButton()}>
               <Text style={styles.closeButtonText}>✕</Text>
             </Pressable>
           </View>
@@ -124,13 +125,19 @@ export const CounterProposeModal = memo(function CounterProposeModal({
           </ScrollView>
 
           <View style={styles.footer}>
-            <Pressable style={styles.cancelButton} onPress={onClose} disabled={isSubmitting}>
+            <Pressable
+              style={styles.cancelButton}
+              onPress={onClose}
+              disabled={isSubmitting}
+              {...a11y.button('Cancelar', isSubmitting)}
+            >
               <Text style={styles.cancelButtonText}>Cancelar</Text>
             </Pressable>
             <Pressable
               style={[styles.submitButton, isSubmitting && styles.submitButtonDisabled]}
               onPress={handleSubmit}
               disabled={isSubmitting}
+              {...a11y.button('Enviar contraproposta', isSubmitting)}
             >
               <Text style={styles.submitButtonText}>
                 {isSubmitting ? 'Enviando...' : 'Contrapropor'}

--- a/mobile/components/DateInput/index.tsx
+++ b/mobile/components/DateInput/index.tsx
@@ -6,6 +6,7 @@ import {
   convertDateFromAPI,
 } from '@/utils/validation/dateHelpers';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface DateInputProps extends Omit<TextInputProps, 'value' | 'onChangeText'> {
   value: string;
@@ -41,6 +42,7 @@ export const DateInput = memo(function DateInput({
   return (
     <View style={styles.container}>
       <TextInput
+        {...a11y.input('Data', 'Formato dia, mês, ano')}
         style={[styles.input, error && styles.inputError]}
         value={displayValue}
         onChangeText={handleChange}

--- a/mobile/components/FilterButton.tsx
+++ b/mobile/components/FilterButton.tsx
@@ -19,6 +19,9 @@ export function FilterButton<T extends string>({
     <Pressable
       style={[styles.filterButton, isActive && styles.filterButtonActive]}
       onPress={() => onPress(value)}
+      accessibilityRole="button"
+      accessibilityLabel={`Filtro: ${label}`}
+      accessibilityState={{ selected: isActive }}
     >
       <Text style={[styles.filterButtonText, isActive && styles.filterButtonTextActive]}>
         {label}

--- a/mobile/components/Input/index.tsx
+++ b/mobile/components/Input/index.tsx
@@ -10,6 +10,7 @@ import {
 import { styles } from './styles';
 import { Controller, FieldValues, UseControllerProps } from 'react-hook-form';
 import { forwardRef, useState } from 'react';
+import { a11y } from '@/utils/accessibility';
 
 interface InputProps<T extends FieldValues = FieldValues> {
   formProps: UseControllerProps<T>;
@@ -36,6 +37,7 @@ const Input = forwardRef<TextInput, InputProps<any>>(
           render={({ field }) => (
             <TextInput
               ref={ref}
+              {...a11y.input(inputProps.placeholder ?? '')}
               style={[
                 styles.input,
                 isFocused && styles.inputFocused,

--- a/mobile/components/MedicationAppointmentCard/index.tsx
+++ b/mobile/components/MedicationAppointmentCard/index.tsx
@@ -12,6 +12,7 @@ import {
   formatAppointmentTime,
 } from '@/utils/businessRules/appointmentRules';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface MedicationAppointmentCardProps {
   appointment: MedicationAppointment;
@@ -123,12 +124,17 @@ export const MedicationAppointmentCard = memo(function MedicationAppointmentCard
 
         {showActions && (
           <View style={styles.actions}>
-            <Pressable style={[styles.button, styles.acceptButton]} onPress={onAccept}>
+            <Pressable
+              style={[styles.button, styles.acceptButton]}
+              onPress={onAccept}
+              {...a11y.button('Aceitar proposta de agendamento')}
+            >
               <Text style={styles.buttonText}>Aceitar</Text>
             </Pressable>
             <Pressable
               style={[styles.button, styles.counterProposeButton]}
               onPress={() => setShowCounterProposeModal(true)}
+              {...a11y.button('Contrapropor novo horário')}
             >
               <Text style={styles.buttonText}>Contrapropor</Text>
             </Pressable>
@@ -143,7 +149,11 @@ export const MedicationAppointmentCard = memo(function MedicationAppointmentCard
 
         {showConfirm && (
           <View style={styles.actions}>
-            <Pressable style={[styles.button, styles.confirmButton]} onPress={onConfirmDelivery}>
+            <Pressable
+              style={[styles.button, styles.confirmButton]}
+              onPress={onConfirmDelivery}
+              {...a11y.button('Confirmar entrega do medicamento')}
+            >
               <Text style={styles.buttonText}>Confirmar Entrega</Text>
             </Pressable>
           </View>

--- a/mobile/components/MedicationOfferingCard/index.tsx
+++ b/mobile/components/MedicationOfferingCard/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { MedicationOffering } from '@/types/medicationOffering';
 import { Colors } from '@/constants/Colors';
+import { a11y } from '@/utils/accessibility';
 
 interface MedicationOfferingCardProps {
   offering: MedicationOffering;
@@ -43,10 +44,18 @@ export function MedicationOfferingCard({
       </View>
 
       <View style={styles.actions}>
-        <Pressable style={styles.editButton} onPress={onEdit}>
+        <Pressable
+          style={styles.editButton}
+          onPress={onEdit}
+          {...a11y.button('Editar medicamento')}
+        >
           <Text style={styles.editButtonText}>Editar</Text>
         </Pressable>
-        <Pressable style={styles.deleteButton} onPress={onDelete}>
+        <Pressable
+          style={styles.deleteButton}
+          onPress={onDelete}
+          {...a11y.button('Excluir medicamento')}
+        >
           <Text style={styles.deleteButtonText}>Excluir</Text>
         </Pressable>
       </View>

--- a/mobile/components/MedicationRequestCard/index.tsx
+++ b/mobile/components/MedicationRequestCard/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { MedicationRequest } from '@/types/medicationRequest';
 import { RequestStatusBadge } from '@/components/RequestStatusBadge';
 import { Colors } from '@/constants/Colors';
+import { a11y } from '@/utils/accessibility';
 
 interface MedicationRequestCardProps {
   request: MedicationRequest;
@@ -87,10 +88,18 @@ export function MedicationRequestCard({
 
       {variant === 'doctor' && isPending && (
         <View style={styles.actions}>
-          <Pressable style={[styles.button, styles.confirmButton]} onPress={onConfirm}>
+          <Pressable
+            style={[styles.button, styles.confirmButton]}
+            onPress={onConfirm}
+            {...a11y.button('Confirmar solicitação')}
+          >
             <Text style={styles.buttonText}>Confirmar</Text>
           </Pressable>
-          <Pressable style={[styles.button, styles.rejectButton]} onPress={onReject}>
+          <Pressable
+            style={[styles.button, styles.rejectButton]}
+            onPress={onReject}
+            {...a11y.button('Recusar solicitação')}
+          >
             <Text style={styles.buttonText}>Recusar</Text>
           </Pressable>
         </View>
@@ -98,7 +107,11 @@ export function MedicationRequestCard({
 
       {variant === 'receptor' && request.status === 'confirmed' && !hasAppointment && (
         <View style={styles.actions}>
-          <Pressable style={[styles.button, styles.scheduleButton]} onPress={onSchedule}>
+          <Pressable
+            style={[styles.button, styles.scheduleButton]}
+            onPress={onSchedule}
+            {...a11y.button('Agendar retirada do medicamento')}
+          >
             <Text style={styles.buttonText}>Agendar Retirada</Text>
           </Pressable>
         </View>

--- a/mobile/components/PrimaryButton/index.tsx
+++ b/mobile/components/PrimaryButton/index.tsx
@@ -1,13 +1,16 @@
 import { Pressable, Text, PressableProps } from 'react-native';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface PrimaryButtonProps extends PressableProps {
   label: string;
 }
 
-export default function PrimaryButton({ label, ...props }: PrimaryButtonProps) {
+export default function PrimaryButton({ label, disabled, ...props }: PrimaryButtonProps) {
   return (
     <Pressable
+      {...a11y.button(label, disabled ?? undefined)}
+      disabled={disabled}
       {...props}
       style={({ pressed }) => [styles.buttonPrimary, pressed && styles.buttonHover]}
     >

--- a/mobile/components/RequestStatusBadge/index.tsx
+++ b/mobile/components/RequestStatusBadge/index.tsx
@@ -5,6 +5,7 @@ import {
   REQUEST_STATUS_LABELS,
   REQUEST_STATUS_COLORS,
 } from '@/types/medicationRequest';
+import { a11y } from '@/utils/accessibility';
 
 interface RequestStatusBadgeProps {
   status: MedicationRequestStatus;
@@ -16,7 +17,7 @@ export function RequestStatusBadge({ status }: RequestStatusBadgeProps) {
   const label = REQUEST_STATUS_LABELS[status];
 
   return (
-    <View style={[styles.badge, { backgroundColor }]}>
+    <View style={[styles.badge, { backgroundColor }]} {...a11y.badge(label)}>
       <Text style={[styles.text, { color: textColor }]}>{label}</Text>
     </View>
   );

--- a/mobile/components/SecondaryButton/index.tsx
+++ b/mobile/components/SecondaryButton/index.tsx
@@ -1,13 +1,16 @@
 import { Pressable, Text, PressableProps } from 'react-native';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface SecondaryButtonProps extends PressableProps {
   label: string;
 }
 
-export default function SecondaryButton({ label, ...props }: SecondaryButtonProps) {
+export default function SecondaryButton({ label, disabled, ...props }: SecondaryButtonProps) {
   return (
     <Pressable
+      {...a11y.button(label, disabled ?? undefined)}
+      disabled={disabled}
       {...props}
       style={({ pressed }) => [styles.buttonSecondary, pressed && styles.buttonHoverSecondary]}
     >

--- a/mobile/components/Select/select.tsx
+++ b/mobile/components/Select/select.tsx
@@ -16,6 +16,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { Colors } from '@/constants/Colors';
+import { a11y } from '@/utils/accessibility';
 
 interface SelectProps<T extends FieldValues = FieldValues> {
   formProps: UseControllerProps<T>;
@@ -86,6 +87,7 @@ const Select = forwardRef<Picker<string | number> | { focus: () => void } | null
                   hasError && styles.selectContainerError,
                   selectViewStyle,
                 ]}
+                {...a11y.input(selectProps.placeholder ?? 'Selecione uma opção')}
               >
                 <Picker
                   // No Android, o ref é passado para o Picker para suportar navegação entre campos

--- a/mobile/components/TimeInput/index.tsx
+++ b/mobile/components/TimeInput/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, memo } from 'react';
 import { View, TextInput, Text, TextInputProps } from 'react-native';
 import { formatTimeInput } from '@/utils/validation/timeHelpers';
 import { styles } from './styles';
+import { a11y } from '@/utils/accessibility';
 
 interface TimeInputProps extends Omit<TextInputProps, 'value' | 'onChangeText'> {
   value: string;
@@ -28,6 +29,7 @@ export const TimeInput = memo(function TimeInput({
   return (
     <View style={styles.container}>
       <TextInput
+        {...a11y.input('Horário', 'Formato hora, minutos')}
         style={[styles.input, error && styles.inputError]}
         value={value}
         onChangeText={handleChange}

--- a/mobile/utils/accessibility.ts
+++ b/mobile/utils/accessibility.ts
@@ -1,0 +1,50 @@
+import { AccessibilityRole } from 'react-native';
+
+type A11yProps = {
+  accessibilityRole?: AccessibilityRole;
+  accessibilityLabel: string;
+  accessibilityHint?: string;
+  accessibilityState?: { disabled?: boolean; selected?: boolean };
+};
+
+export const a11y = {
+  button: (label: string, disabled?: boolean): A11yProps => ({
+    accessibilityRole: 'button',
+    accessibilityLabel: label,
+    ...(disabled !== undefined && { accessibilityState: { disabled } }),
+  }),
+
+  input: (label: string, hint?: string): A11yProps => ({
+    accessibilityLabel: label,
+    ...(hint && { accessibilityHint: hint }),
+  }),
+
+  link: (label: string): A11yProps => ({
+    accessibilityRole: 'link',
+    accessibilityLabel: label,
+  }),
+
+  card: (summary: string): A11yProps => ({
+    accessibilityLabel: summary,
+  }),
+
+  badge: (status: string): A11yProps => ({
+    accessibilityLabel: `Status: ${status}`,
+  }),
+
+  radioButton: (label: string, selected: boolean): A11yProps => ({
+    accessibilityRole: 'radio',
+    accessibilityLabel: label,
+    accessibilityState: { selected },
+  }),
+
+  backButton: (): A11yProps => ({
+    accessibilityRole: 'button',
+    accessibilityLabel: 'Voltar',
+  }),
+
+  closeButton: (): A11yProps => ({
+    accessibilityRole: 'button',
+    accessibilityLabel: 'Fechar',
+  }),
+};


### PR DESCRIPTION
## Summary

- Create centralized accessibility utility (`utils/accessibility.ts`) with helpers for screen reader support
- Add a11y props to 14 interactive components enabling VoiceOver/TalkBack support
- Closes #90

## Components Updated

### High Priority
- `Input` - accessibilityLabel from placeholder
- `PrimaryButton` / `SecondaryButton` - button role with disabled state
- `MedicationOfferingCard` - Edit/Delete buttons accessible
- `MedicationRequestCard` - Confirm/Reject/Schedule buttons accessible  
- `MedicationAppointmentCard` - Accept/CounterPropose/Confirm buttons accessible

### Badges
- `AppointmentStatusBadge` / `RequestStatusBadge` - Status announcements

### Medium Priority
- `DateInput` / `TimeInput` - Input labels with format hints
- `FilterButton` - Button with selected state
- `ArrowBackButton` - Back navigation
- `CounterProposeModal` - Close and action buttons
- `AddressSelector` - Radio button roles
- `Select` - Android picker accessibility

## Test plan

- [x] All 185 tests pass
- [x] No new type errors introduced
- [ ] Manual test with VoiceOver (iOS)
- [ ] Manual test with TalkBack (Android)

🤖 Generated with [Claude Code](https://claude.com/claude-code)