### PR TITLE
fix(mobile): resolve 13 TypeScript errors and add check-types to pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -61,8 +61,16 @@ if echo "$CHANGED_FILES" | grep -q "^mobile/"; then
     exit 1
   fi
 
+  # Rodar o TypeScript type check
+  echo "${Blue}2. Verificando tipos TypeScript${NC}"
+  npm run check-types
+  if [ $? -ne 0 ]; then
+    echo "${Red} O TypeScript encontrou erros de tipo. ${NC}"
+    exit 1
+  fi
+
   # Rodar os testes
-  echo "${Blue}2. Rodando o Testes em paralelo${NC}"
+  echo "${Blue}3. Rodando o Testes em paralelo${NC}"
   npm run test
   if [ $? -ne 0 ]; then
     echo "${Red} Tivemos erro em algum teste, revise o código ou o teste! ${NC}"
@@ -72,7 +80,7 @@ if echo "$CHANGED_FILES" | grep -q "^mobile/"; then
   # Formatar cada arquivo alterado usando o Prettier
   STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E "\.(js|jsx|ts|tsx)$" | sed 's|^mobile/||') || true
 
-  echo "${Blue}3. Formatando os arquivos com o Prettier${NC}"
+  echo "${Blue}4. Formatando os arquivos com o Prettier${NC}"
 
   for FILE in $STAGED_FILES
   do

--- a/mobile/__tests__/stores/authStore.test.ts
+++ b/mobile/__tests__/stores/authStore.test.ts
@@ -57,6 +57,7 @@ describe('authStore', () => {
       name: 'Dr. João Silva',
       email: 'joao@example.com',
       role: 'doctor' as const,
+      status: 'approved' as const,
     };
     const mockAccessToken = '1|access_token_abc123';
     const mockRefreshToken = '2|refresh_token_xyz789';
@@ -140,6 +141,7 @@ describe('authStore', () => {
       name: 'Dr. João Silva',
       email: 'joao@example.com',
       role: 'doctor' as const,
+      status: 'approved' as const,
     };
     const initialAccessToken = '1|old_access_token';
     const initialRefreshToken = '2|refresh_token';
@@ -267,7 +269,13 @@ describe('authStore', () => {
     beforeEach(() => {
       // Setup authenticated state
       useAuthStore.setState({
-        user: { id: 1, name: 'Test', email: 'test@test.com', role: 'doctor' },
+        user: {
+          id: 1,
+          name: 'Test',
+          email: 'test@test.com',
+          role: 'doctor',
+          status: 'approved' as const,
+        },
         token: '1|access_token',
         refreshToken: '2|refresh_token',
         expiresAt: Date.now() + 3600000,
@@ -364,7 +372,13 @@ describe('authStore', () => {
     it('should restore access token from SecureStore', async () => {
       const mockToken = '1|access_token';
       const mockRefreshToken = '2|refresh_token';
-      const mockUser = { id: 1, name: 'Test', email: 'test@test.com', role: 'doctor' };
+      const mockUser = {
+        id: 1,
+        name: 'Test',
+        email: 'test@test.com',
+        role: 'doctor',
+        status: 'approved',
+      };
 
       (SecureStore.getItemAsync as jest.Mock)
         .mockResolvedValueOnce(mockToken) // auth_token
@@ -380,7 +394,13 @@ describe('authStore', () => {
     it('should restore refresh token from SecureStore', async () => {
       const mockToken = '1|access_token';
       const mockRefreshToken = '2|refresh_token';
-      const mockUser = { id: 1, name: 'Test', email: 'test@test.com', role: 'doctor' };
+      const mockUser = {
+        id: 1,
+        name: 'Test',
+        email: 'test@test.com',
+        role: 'doctor',
+        status: 'approved',
+      };
 
       (SecureStore.getItemAsync as jest.Mock)
         .mockResolvedValueOnce(mockToken) // auth_token
@@ -396,7 +416,13 @@ describe('authStore', () => {
     it('should restore user from AsyncStorage', async () => {
       const mockToken = '1|access_token';
       const mockRefreshToken = '2|refresh_token';
-      const mockUser = { id: 1, name: 'Test', email: 'test@test.com', role: 'doctor' };
+      const mockUser = {
+        id: 1,
+        name: 'Test',
+        email: 'test@test.com',
+        role: 'doctor',
+        status: 'approved',
+      };
 
       (SecureStore.getItemAsync as jest.Mock)
         .mockResolvedValueOnce(mockToken)
@@ -412,7 +438,13 @@ describe('authStore', () => {
     it('should set isAuthenticated to true when tokens exist', async () => {
       const mockToken = '1|access_token';
       const mockRefreshToken = '2|refresh_token';
-      const mockUser = { id: 1, name: 'Test', email: 'test@test.com', role: 'doctor' };
+      const mockUser = {
+        id: 1,
+        name: 'Test',
+        email: 'test@test.com',
+        role: 'doctor',
+        status: 'approved',
+      };
 
       (SecureStore.getItemAsync as jest.Mock)
         .mockResolvedValueOnce(mockToken)
@@ -428,7 +460,13 @@ describe('authStore', () => {
     it('should set Authorization header on api', async () => {
       const mockToken = '1|access_token';
       const mockRefreshToken = '2|refresh_token';
-      const mockUser = { id: 1, name: 'Test', email: 'test@test.com', role: 'doctor' };
+      const mockUser = {
+        id: 1,
+        name: 'Test',
+        email: 'test@test.com',
+        role: 'doctor',
+        status: 'approved',
+      };
 
       (SecureStore.getItemAsync as jest.Mock)
         .mockResolvedValueOnce(mockToken)

--- a/mobile/app/(auth)/dashboard.tsx
+++ b/mobile/app/(auth)/dashboard.tsx
@@ -1,5 +1,5 @@
 import { View, Text, StyleSheet } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, Href } from 'expo-router';
 import { useAuthStore } from '@/stores/authStore';
 import PrimaryButton from '@/components/PrimaryButton';
 import SecondaryButton from '@/components/SecondaryButton';
@@ -41,11 +41,11 @@ export default function Dashboard() {
 
   // Receptor navigation
   const handleSearchMedications = () => {
-    router.push('/(auth)/receptor/search');
+    router.push('/(auth)/receptor/(tabs)/search' as Href);
   };
 
   const handleMyRequests = () => {
-    router.push('/(auth)/receptor/requests');
+    router.push('/(auth)/receptor/(tabs)/requests' as Href);
   };
 
   return (

--- a/mobile/app/(auth)/receptor/(tabs)/search.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/search.tsx
@@ -27,7 +27,7 @@ export default function SearchScreen() {
 
   const fetchOfferingsFn = useCallback(
     async (page: number) => {
-      return medicationOfferingService.searchOfferingsPaginated(searchQuery, page);
+      return medicationOfferingService.searchPaginated(searchQuery, page);
     },
     [searchQuery]
   );

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { Stack, router } from 'expo-router';
+import { Stack, router, Href } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect, useRef } from 'react';
 import 'react-native-reanimated';
@@ -39,8 +39,8 @@ export default function RootLayout() {
   });
 
   const checkAuth = useAuthStore((state) => state.checkAuth);
-  const notificationListener = useRef<Subscription>();
-  const responseListener = useRef<Subscription>();
+  const notificationListener = useRef<Subscription | null>(null);
+  const responseListener = useRef<Subscription | null>(null);
 
   useEffect(() => {
     if (error) throw error;
@@ -77,9 +77,9 @@ export default function RootLayout() {
       if (data?.type === 'appointment_reminder') {
         const user = useAuthStore.getState().user;
         if (user?.role === 'doctor') {
-          router.push('/(auth)/appointments/received');
+          router.push('/(auth)/medication-appointments' as Href);
         } else {
-          router.push('/(auth)/receptor/appointments');
+          router.push('/(auth)/receptor/(tabs)/appointments' as Href);
         }
       }
     });

--- a/mobile/components/DateInput/index.tsx
+++ b/mobile/components/DateInput/index.tsx
@@ -8,7 +8,7 @@ import {
 import { styles } from './styles';
 import { a11y } from '@/utils/accessibility';
 
-interface DateInputProps extends Omit<TextInputProps, 'value' | 'onChangeText'> {
+interface DateInputProps extends Omit<TextInputProps, 'value' | 'onChangeText' | 'onChange'> {
   value: string;
   onChange: (date: string) => void;
   error?: string;

--- a/mobile/components/TimeInput/index.tsx
+++ b/mobile/components/TimeInput/index.tsx
@@ -4,7 +4,7 @@ import { formatTimeInput } from '@/utils/validation/timeHelpers';
 import { styles } from './styles';
 import { a11y } from '@/utils/accessibility';
 
-interface TimeInputProps extends Omit<TextInputProps, 'value' | 'onChangeText'> {
+interface TimeInputProps extends Omit<TextInputProps, 'value' | 'onChangeText' | 'onChange'> {
   value: string;
   onChange: (time: string) => void;
   error?: string;

--- a/mobile/screens/ReceptorRegistration/index.tsx
+++ b/mobile/screens/ReceptorRegistration/index.tsx
@@ -9,7 +9,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, Href } from 'expo-router';
 import { Input } from '@/components/Input';
 import PrimaryButton from '@/components/PrimaryButton';
 import ArrowBackButton from '@/components/ArrowBackButton';
@@ -122,7 +122,7 @@ export function ReceptorRegistrationScreen() {
     }
 
     if (success) {
-      router.replace('/(auth)/receptor');
+      router.replace('/(auth)/receptor' as Href);
     }
   };
 

--- a/mobile/services/receptorService.ts
+++ b/mobile/services/receptorService.ts
@@ -19,7 +19,8 @@ export interface ReceptorRegistrationResponse {
       name: string;
       email: string;
       phone_number: string;
-      role: string;
+      role: 'doctor' | 'receptor';
+      status: 'pending' | 'approved' | 'rejected';
     };
     token: string;
   };

--- a/mobile/stores/authStore.ts
+++ b/mobile/stores/authStore.ts
@@ -16,6 +16,7 @@ export interface User {
   email: string;
   phone_number?: string;
   role: 'doctor' | 'receptor';
+  status: 'pending' | 'approved' | 'rejected';
 }
 
 interface AuthStoreState {

--- a/mobile/types/user.ts
+++ b/mobile/types/user.ts
@@ -17,18 +17,20 @@ export enum UserRole {
   Receptor = 'receptor',
 }
 
+export type UserStatusValue = UserStatus | 'pending' | 'approved' | 'rejected';
+
 /**
  * Checks if user can access the app based on their status.
  * Mirrors backend logic from UserStatus::canAccess()
  */
-export const canUserAccessApp = (status: UserStatus): boolean => {
-  return status === UserStatus.Approved;
+export const canUserAccessApp = (status: UserStatusValue): boolean => {
+  return String(status) === 'approved';
 };
 
 /**
  * Checks if user is blocked from accessing the app.
  * Inverse of canUserAccessApp for readability.
  */
-export const isUserBlocked = (status: UserStatus): boolean => {
-  return status !== UserStatus.Approved;
+export const isUserBlocked = (status: UserStatusValue): boolean => {
+  return String(status) !== 'approved';
 };


### PR DESCRIPTION
## Summary

- Resolve 13 TypeScript errors found by `npm run check-types`
- Add TypeScript type checking to pre-commit hook for mobile project
- Ensure type safety is enforced before commits

## Changes

### Type Fixes
- Add `status` field to `User` interface in `authStore.ts`
- Add `status` field to `ReceptorRegistrationResponse` in `receptorService.ts`
- Fix `DateInput` and `TimeInput` to properly omit `onChange` from `TextInputProps`
- Fix `router.push` calls to use proper `Href` type casting
- Fix `searchOfferingsPaginated` to use correct method name `searchPaginated`
- Fix `useRef` calls to include `null` initial value for `Subscription` type
- Update `isUserBlocked`/`canUserAccessApp` to accept string literal types
- Update `authStore` tests to include `status` in mock users

### Pre-commit Hook
- Add `npm run check-types` step to mobile pre-commit hook (step 2)
- Renumber subsequent steps accordingly

## Test plan
- [x] Run `npm run check-types` - returns 0 errors
- [x] Run `npm run lint` - passes (only warnings)
- [x] Run `npm test` - all tests pass
- [x] Pre-commit hook runs successfully with new type check step

Closes #91