### PR TITLE
perf(web): disable Xdebug during tests to fix slow performance test

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,9 +21,9 @@ if echo "$CHANGED_FILES" | grep -q "^web/"; then
     exit 1
   fi
 
-  # Rodar os testes (excluindo testes lentos)
-  echo "${Blue}2. Rodando o Testes em paralelo${NC}"
-  php artisan test --parallel --exclude-group=slow
+  # Rodar os testes (sem Xdebug overhead, modo sequencial para confiabilidade)
+  echo "${Blue}2. Rodando os Testes${NC}"
+  XDEBUG_MODE=off php artisan test
   if [ $? -ne 0 ]; then
     echo "${Red} Tivemos erro em algum teste, revise o código ou o teste! ${NC}"
     exit 1

--- a/web/composer.json
+++ b/web/composer.json
@@ -75,21 +75,14 @@
             "./vendor/bin/pint",
             "./vendor/bin/pest --parallel"
         ],
-        "t": [
-            "./vendor/bin/pest"
-        ],
-        "tp": [
-            "./vendor/bin/pest --parallel"
-        ],
-        "td": [
-            "./vendor/bin/pest --dirty"
-        ],
-        "tr": [
-            "./vendor/bin/pest --retry"
-        ],
-        "tf": [
-            "./vendor/bin/pest --filter "
-        ]
+        "t": "@php -dxdebug.mode=off ./vendor/bin/pest",
+        "tp": "@php -dxdebug.mode=off ./vendor/bin/pest --parallel",
+        "td": "@php -dxdebug.mode=off ./vendor/bin/pest --dirty",
+        "tr": "@php -dxdebug.mode=off ./vendor/bin/pest --retry",
+        "tf": "@php -dxdebug.mode=off ./vendor/bin/pest --filter ",
+        "t:coverage": "@php -dpcov.enabled=1 -dxdebug.mode=off -d memory_limit=-1 ./vendor/bin/pest --coverage",
+        "t:coverage:html": "@php -dpcov.enabled=1 -dxdebug.mode=off -d memory_limit=-1 ./vendor/bin/pest --coverage --coverage-html=build/coverage",
+        "t:type-coverage": "@php -dxdebug.mode=off -d memory_limit=-1 ./vendor/bin/pest --type-coverage"
     },
     "extra": {
         "laravel": {

--- a/web/phpunit.xml
+++ b/web/phpunit.xml
@@ -3,6 +3,11 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
+         executionOrder="random"
+         failOnWarning="true"
+         failOnRisky="true"
+         beStrictAboutOutputDuringTests="true"
+         cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="Unit">

--- a/web/tests/Unit/Jobs/ProcessDrugCsvImportJobTest.php
+++ b/web/tests/Unit/Jobs/ProcessDrugCsvImportJobTest.php
@@ -234,9 +234,8 @@ describe('ProcessDrugCsvImportJob', function (): void {
 
         // Assert
         expect(Drug::count())->toBe(10000);
-        // Allow up to 15 seconds to accommodate Xdebug overhead when enabled
-        expect($endTime - $startTime)->toBeLessThan(15);
-    })->group('slow');
+        expect($endTime - $startTime)->toBeLessThan(10);
+    });
 
     it('handles missing required columns gracefully', function (): void {
         // Arrange


### PR DESCRIPTION
## Summary

- Disable Xdebug during test execution using `-dxdebug.mode=off` in composer scripts
- Add PCOV-based coverage scripts for faster coverage generation
- Update pre-commit hook to run tests without Xdebug overhead
- Revert performance test threshold from 15s back to 10s
- Add strict PHPUnit attributes following Nuno Maduro's standards

## Context

The performance test `processes large CSV files efficiently` was failing because Xdebug's overhead (~11.5s) exceeded the 10s threshold. A temporary fix increased the threshold to 15s and excluded the test from pre-commit.

This PR implements a proper solution by disabling Xdebug during test execution, bringing the test time down to ~6.5s.

## Benchmarks

| Scenario | Time |
|----------|------|
| Xdebug mode=develop | ~11.5s |
| Xdebug mode=off | ~6.5s |
| Threshold | 10s |

## Test plan

- [x] Performance test passes in < 10s with `XDEBUG_MODE=off`
- [x] Full test suite passes (552 tests)
- [x] Pre-commit hook executes successfully
- [ ] Coverage scripts work with PCOV installed

Resolves #130