### PR TITLE
feat(api): add security headers middleware

### DIFF
--- a/web/app/Http/Middleware/SecurityHeaders.php
+++ b/web/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SecurityHeaders
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        if (app()->environment('production')) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
+
+        return $response;
+    }
+}

--- a/web/bootstrap/app.php
+++ b/web/bootstrap/app.php
@@ -21,6 +21,10 @@ return Application::configure(basePath: dirname(__DIR__))
             'approved'  => App\Http\Middleware\EnsureUserIsApproved::class,
             'abilities' => Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
         ]);
+
+        $middleware->api(append: [
+            App\Http\Middleware\SecurityHeaders::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->render(function (ThrottleRequestsException $e, $request) {


### PR DESCRIPTION
## Summary

- Create `SecurityHeaders` middleware for API routes
- Add security headers:
  - `X-Frame-Options: DENY` - prevents clickjacking
  - `X-Content-Type-Options: nosniff` - prevents MIME sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin` - controls referrer info
  - `Strict-Transport-Security` - enforces HTTPS (production only)

## Test plan

- [x] All 551 tests passing
- [x] PHPStan analysis clean

Closes #96