### PR TITLE
fix(api): configure CORS with explicit methods and headers

### DIFF
--- a/web/config/cors.php
+++ b/web/config/cors.php
@@ -17,15 +17,15 @@ return [
     |
     */
 
-    'paths' => ['*'],
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
 
-    'allowed_methods' => ['*'],
+    'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 
     'allowed_origins' => [env('FRONTEND_URL', 'http://localhost:3000')],
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['*'],
+    'allowed_headers' => ['Authorization', 'Content-Type', 'Accept', 'X-Requested-With'],
 
     'exposed_headers' => [],
 


### PR DESCRIPTION
## Summary

- Replace CORS wildcards with explicit configuration
- Restrict `paths` to `api/*` and `sanctum/csrf-cookie`
- Specify only used HTTP methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`
- Specify only required headers: `Authorization`, `Content-Type`, `Accept`, `X-Requested-With`

## Why

Using wildcards (`*`) for CORS methods and headers is a security risk. Explicit configuration ensures only necessary cross-origin operations are allowed.

## Test plan

- [x] All tests passing
- [x] PHPStan analysis clean

Closes #93