### PR TITLE
refactor(mobile): extract pagination constants to shared config

### DIFF
--- a/mobile/app/(auth)/doctor/history.tsx
+++ b/mobile/app/(auth)/doctor/history.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
 import { Colors } from '@/constants/Colors';
+import { Pagination } from '@/constants/Pagination';
 import { MedicationAppointment } from '@/types/medicationAppointment';
 import { ListFooterLoader } from '@/components/ListFooterLoader';
 import { usePagination } from '@/hooks/usePagination';
@@ -154,7 +155,7 @@ export default function DoctorHistoryScreen() {
             />
           }
           onEndReached={loadMore}
-          onEndReachedThreshold={0.5}
+          onEndReachedThreshold={Pagination.END_REACHED_THRESHOLD}
           ListFooterComponent={<ListFooterLoader isLoading={isLoadingMore} />}
           ListEmptyComponent={renderEmpty}
           showsVerticalScrollIndicator={false}

--- a/mobile/app/(auth)/receptor/(tabs)/history.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/history.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { router } from 'expo-router';
 import { Colors } from '@/constants/Colors';
+import { Pagination } from '@/constants/Pagination';
 import { MedicationAppointment } from '@/types/medicationAppointment';
 import { ListFooterLoader } from '@/components/ListFooterLoader';
 import { usePagination } from '@/hooks/usePagination';
@@ -187,7 +188,7 @@ export default function ReceptorHistoryScreen() {
             />
           }
           onEndReached={loadMore}
-          onEndReachedThreshold={0.5}
+          onEndReachedThreshold={Pagination.END_REACHED_THRESHOLD}
           ListFooterComponent={<ListFooterLoader isLoading={isLoadingMore} />}
           ListEmptyComponent={renderEmpty}
           showsVerticalScrollIndicator={false}

--- a/mobile/app/(auth)/receptor/(tabs)/search.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/search.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { router, Href } from 'expo-router';
 import { Colors } from '@/constants/Colors';
+import { Pagination } from '@/constants/Pagination';
 import { SearchResultCard } from '@/components/SearchResultCard';
 import { ListFooterLoader } from '@/components/ListFooterLoader';
 import { medicationOfferingService } from '@/services/medicationOfferingService';
@@ -180,7 +181,7 @@ export default function SearchScreen() {
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
           onEndReached={loadMore}
-          onEndReachedThreshold={0.5}
+          onEndReachedThreshold={Pagination.END_REACHED_THRESHOLD}
           ListFooterComponent={<ListFooterLoader isLoading={isLoadingMore} />}
         />
       ) : (

--- a/mobile/constants/Pagination.ts
+++ b/mobile/constants/Pagination.ts
@@ -1,0 +1,12 @@
+export const Pagination = {
+  /**
+   * Distance from the end of the list to trigger loadMore.
+   * 0.5 = starts loading when user is 50% from the end.
+   */
+  END_REACHED_THRESHOLD: 0.5,
+
+  /**
+   * Initial page for all paginated lists.
+   */
+  INITIAL_PAGE: 1,
+} as const;


### PR DESCRIPTION
## Summary

- Create `constants/Pagination.ts` with documented constants
- Replace hardcoded `onEndReachedThreshold={0.5}` with `Pagination.END_REACHED_THRESHOLD`
- Add `INITIAL_PAGE` constant for future use

## Files changed

- **New:** `mobile/constants/Pagination.ts`
- `mobile/app/(auth)/doctor/history.tsx`
- `mobile/app/(auth)/receptor/(tabs)/search.tsx`
- `mobile/app/(auth)/receptor/(tabs)/history.tsx`

## Test plan

- [x] TypeScript check passing
- [x] All 185 tests passing
- [x] ESLint passing (only pre-existing warnings)

Closes #122