### PR TITLE
refactor(mobile): extract date formatters to shared utils

### DIFF
--- a/mobile/app/(auth)/doctor/history.tsx
+++ b/mobile/app/(auth)/doctor/history.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
 import { Colors } from '@/constants/Colors';
 import { Pagination } from '@/constants/Pagination';
+import { formatLongDate } from '@/utils/dateFormatters';
 import { MedicationAppointment } from '@/types/medicationAppointment';
 import { ListFooterLoader } from '@/components/ListFooterLoader';
 import { usePagination } from '@/hooks/usePagination';
@@ -23,15 +24,6 @@ export default function DoctorHistoryScreen() {
   } = usePagination<MedicationAppointment>({
     fetchFn: fetchDoctorHistoryFn,
   });
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('pt-BR', {
-      day: '2-digit',
-      month: 'long',
-      year: 'numeric',
-    });
-  };
 
   const renderItem = ({ item }: { item: MedicationAppointment }) => {
     const drug = item.medication_request?.medication_offering?.drug;
@@ -74,7 +66,7 @@ export default function DoctorHistoryScreen() {
             <View style={styles.infoRow}>
               <Text style={styles.infoLabel}>Validade:</Text>
               <Text style={styles.infoValue}>
-                {formatDate(item.medication_request.medication_offering.expires_at)}
+                {formatLongDate(item.medication_request.medication_offering.expires_at)}
               </Text>
             </View>
           )}
@@ -90,7 +82,7 @@ export default function DoctorHistoryScreen() {
 
           <View style={styles.dateRow}>
             <Text style={styles.dateIcon}>📅</Text>
-            <Text style={styles.dateText}>Doado em {formatDate(item.updated_at)}</Text>
+            <Text style={styles.dateText}>Doado em {formatLongDate(item.updated_at)}</Text>
           </View>
         </View>
       </View>

--- a/mobile/app/(auth)/doctor/ratings.tsx
+++ b/mobile/app/(auth)/doctor/ratings.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
 import { useDoctorRatingStore } from '@/stores/doctorRatingStore';
 import { Colors } from '@/constants/Colors';
+import { formatLongDate } from '@/utils/dateFormatters';
 import { DoctorRating, RATING_LABELS } from '@/types/doctorRating';
 
 export default function DoctorRatingsScreen() {
@@ -12,15 +13,6 @@ export default function DoctorRatingsScreen() {
     fetchMyRatings();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('pt-BR', {
-      day: '2-digit',
-      month: 'long',
-      year: 'numeric',
-    });
-  };
 
   const renderStars = (rating: number) => {
     return (
@@ -81,7 +73,7 @@ export default function DoctorRatingsScreen() {
             {renderStars(item.rating)}
             <Text style={styles.ratingLabel}>{RATING_LABELS[item.rating]}</Text>
           </View>
-          <Text style={styles.date}>{formatDate(item.created_at)}</Text>
+          <Text style={styles.date}>{formatLongDate(item.created_at)}</Text>
         </View>
 
         {item.comment && <Text style={styles.comment}>{item.comment}</Text>}

--- a/mobile/app/(auth)/receptor/(tabs)/history.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/history.tsx
@@ -11,6 +11,7 @@ import {
 import { router } from 'expo-router';
 import { Colors } from '@/constants/Colors';
 import { Pagination } from '@/constants/Pagination';
+import { formatLongDate } from '@/utils/dateFormatters';
 import { MedicationAppointment } from '@/types/medicationAppointment';
 import { ListFooterLoader } from '@/components/ListFooterLoader';
 import { usePagination } from '@/hooks/usePagination';
@@ -32,15 +33,6 @@ export default function ReceptorHistoryScreen() {
   } = usePagination<MedicationAppointment>({
     fetchFn: fetchHistoryFn,
   });
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('pt-BR', {
-      day: '2-digit',
-      month: 'long',
-      year: 'numeric',
-    });
-  };
 
   const handleRateDoctor = (appointment: MedicationAppointment) => {
     const drug = appointment.medication_request?.medication_offering?.drug;
@@ -97,7 +89,7 @@ export default function ReceptorHistoryScreen() {
             <View style={styles.infoRow}>
               <Text style={styles.infoLabel}>Validade:</Text>
               <Text style={styles.infoValue}>
-                {formatDate(item.medication_request.medication_offering.expires_at)}
+                {formatLongDate(item.medication_request.medication_offering.expires_at)}
               </Text>
             </View>
           )}
@@ -113,7 +105,7 @@ export default function ReceptorHistoryScreen() {
 
           <View style={styles.dateRow}>
             <Text style={styles.dateIcon}>📅</Text>
-            <Text style={styles.dateText}>Recebido em {formatDate(item.updated_at)}</Text>
+            <Text style={styles.dateText}>Recebido em {formatLongDate(item.updated_at)}</Text>
           </View>
 
           {/* Rate Button */}

--- a/mobile/app/(auth)/receptor/offering/[id].tsx
+++ b/mobile/app/(auth)/receptor/offering/[id].tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Colors } from '@/constants/Colors';
+import { formatShortDate } from '@/utils/dateFormatters';
 import { MedicationOfferingSearchResult } from '@/types/medicationOffering';
 import { useMedicationRequestStore } from '@/stores/medicationRequestStore';
 import PrimaryButton from '@/components/PrimaryButton';
@@ -68,10 +69,6 @@ export default function OfferingDetailScreen() {
     );
   }
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('pt-BR');
-  };
-
   const isExpired = new Date(offering.expires_at) < new Date();
 
   return (
@@ -107,7 +104,7 @@ export default function OfferingDetailScreen() {
           <View style={styles.detailRow}>
             <Text style={styles.detailLabel}>Validade:</Text>
             <Text style={[styles.detailValue, isExpired && styles.expiredText]}>
-              {formatDate(offering.expires_at)}
+              {formatShortDate(offering.expires_at)}
             </Text>
           </View>
         </View>

--- a/mobile/components/MedicationOfferingCard/index.tsx
+++ b/mobile/components/MedicationOfferingCard/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { MedicationOffering } from '@/types/medicationOffering';
 import { Colors } from '@/constants/Colors';
 import { a11y } from '@/utils/accessibility';
+import { formatShortDate } from '@/utils/dateFormatters';
 
 interface MedicationOfferingCardProps {
   offering: MedicationOffering;
@@ -15,10 +16,6 @@ export function MedicationOfferingCard({
   onEdit,
   onDelete,
 }: MedicationOfferingCardProps) {
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('pt-BR');
-  };
-
   const isExpired = new Date(offering.expires_at) < new Date();
 
   return (
@@ -39,7 +36,7 @@ export function MedicationOfferingCard({
           <Text style={styles.label}>Quantidade:</Text> {offering.quantity} unidades
         </Text>
         <Text style={[styles.detailText, isExpired && styles.expiredText]}>
-          <Text style={styles.label}>Vencimento:</Text> {formatDate(offering.expires_at)}
+          <Text style={styles.label}>Vencimento:</Text> {formatShortDate(offering.expires_at)}
         </Text>
       </View>
 

--- a/mobile/components/MedicationRequestCard/index.tsx
+++ b/mobile/components/MedicationRequestCard/index.tsx
@@ -4,6 +4,7 @@ import { MedicationRequest } from '@/types/medicationRequest';
 import { RequestStatusBadge } from '@/components/RequestStatusBadge';
 import { Colors } from '@/constants/Colors';
 import { a11y } from '@/utils/accessibility';
+import { formatShortDate, formatDateTime } from '@/utils/dateFormatters';
 
 interface MedicationRequestCardProps {
   request: MedicationRequest;
@@ -22,20 +23,6 @@ export function MedicationRequestCard({
   onSchedule,
   hasAppointment = false,
 }: MedicationRequestCardProps) {
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('pt-BR');
-  };
-
-  const formatDateTime = (dateString: string) => {
-    return new Date(dateString).toLocaleString('pt-BR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
   const offering = request.medication_offering;
   const isPending = request.status === 'pending';
 
@@ -57,7 +44,7 @@ export function MedicationRequestCard({
         </Text>
         <Text style={styles.detailText}>
           <Text style={styles.label}>Validade:</Text>{' '}
-          {offering ? formatDate(offering.expires_at) : '-'}
+          {offering ? formatShortDate(offering.expires_at) : '-'}
         </Text>
 
         {variant === 'doctor' && request.receptor && (

--- a/mobile/components/SearchResultCard/index.tsx
+++ b/mobile/components/SearchResultCard/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { MedicationOfferingSearchResult } from '@/types/medicationOffering';
+import { formatShortDate } from '@/utils/dateFormatters';
 import { styles } from './styles';
 
 interface SearchResultCardProps {
@@ -9,10 +10,6 @@ interface SearchResultCardProps {
 }
 
 export function SearchResultCard({ offering, onPress }: SearchResultCardProps) {
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('pt-BR');
-  };
-
   const isExpired = new Date(offering.expires_at) < new Date();
 
   return (
@@ -44,7 +41,7 @@ export function SearchResultCard({ offering, onPress }: SearchResultCardProps) {
               <Text style={styles.label}>Quantidade:</Text> {offering.quantity} unidades
             </Text>
             <Text style={[styles.detailText, isExpired && styles.expiredText]}>
-              <Text style={styles.label}>Validade:</Text> {formatDate(offering.expires_at)}
+              <Text style={styles.label}>Validade:</Text> {formatShortDate(offering.expires_at)}
             </Text>
           </View>
 

--- a/mobile/utils/dateFormatters.ts
+++ b/mobile/utils/dateFormatters.ts
@@ -1,0 +1,31 @@
+/**
+ * Formats a date string to long format: "20 de fevereiro de 2026"
+ */
+export function formatLongDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Formats a date string to short format: "20/02/2026"
+ */
+export function formatShortDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('pt-BR');
+}
+
+/**
+ * Formats a date string to datetime format: "20/02/2026, 14:30"
+ */
+export function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}


### PR DESCRIPTION
## Summary

- Create `utils/dateFormatters.ts` with 3 documented functions:
  - `formatLongDate`: "20 de fevereiro de 2026"
  - `formatShortDate`: "20/02/2026"
  - `formatDateTime`: "20/02/2026, 14:30"

## Files changed

- **New:** `mobile/utils/dateFormatters.ts`
- Removed duplicate `formatDate` from 7 files
- Removed duplicate `formatDateTime` from 1 file

## Impact

- **Lines removed:** 62 (duplicate code)
- **Lines added:** 47 (shared utils + imports)
- **Net reduction:** 15 lines

## Test plan

- [x] TypeScript check passing
- [x] All 185 tests passing
- [x] ESLint passing (only pre-existing warnings)

Closes #121