### PR TITLE
refactor(mobile): create conditional logger to replace console calls

### DIFF
--- a/mobile/screens/DoctorRegistration/DoctorRegistrationFlow/index.tsx
+++ b/mobile/screens/DoctorRegistration/DoctorRegistrationFlow/index.tsx
@@ -10,6 +10,7 @@ import { DoctorAddressStep } from '../steps/DoctorAddressStep';
 import { styles } from './styles';
 import { Colors } from '@/constants/Colors';
 import { UseFormSetError } from 'react-hook-form';
+import { logger } from '@/utils/logger';
 
 interface DoctorRegistrationFlowProps {
   currentStep: number;
@@ -46,8 +47,8 @@ export function DoctorRegistrationFlow({ currentStep }: DoctorRegistrationFlowPr
     const success = await submitDoctorRegistrationForm();
 
     if (!success && setError && validationErrors && error) {
-      console.log('Erro ao registrar médico:', error);
-      console.error('Erro de validação:', validationErrors);
+      logger.log('Erro ao registrar médico:', error);
+      logger.error('Erro de validação:', validationErrors);
       setError(Object.keys(validationErrors)[0], { message: error }, { shouldFocus: true });
     }
 

--- a/mobile/services/authService.ts
+++ b/mobile/services/authService.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError } from 'axios';
 import { User } from '@/stores/authStore';
 import { API_ENDPOINTS } from '@/config/endpoints';
 import { getErrorMessage } from '@/utils/error';
+import { logger } from '@/utils/logger';
 
 export interface LoginCredentials {
   email: string;
@@ -70,7 +71,7 @@ export const authService = {
       const response = await apiClient.post<LoginResponse>(API_ENDPOINTS.AUTH.LOGIN, credentials);
       return response.data;
     } catch (error) {
-      console.error('Erro ao fazer login:', getErrorMessage(error));
+      logger.error('Erro ao fazer login:', getErrorMessage(error));
 
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError<ApiValidationError>;
@@ -130,7 +131,7 @@ export const authService = {
       );
       return response.data;
     } catch (error) {
-      console.error('Erro ao renovar token:', getErrorMessage(error));
+      logger.error('Erro ao renovar token:', getErrorMessage(error));
 
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError<ApiValidationError>;
@@ -177,7 +178,7 @@ export const authService = {
     try {
       await apiClient.post(API_ENDPOINTS.AUTH.LOGOUT);
     } catch (error) {
-      console.error('Erro ao fazer logout:', getErrorMessage(error));
+      logger.error('Erro ao fazer logout:', getErrorMessage(error));
     }
   },
 };

--- a/mobile/services/doctorService.ts
+++ b/mobile/services/doctorService.ts
@@ -1,5 +1,6 @@
 import { apiClient } from './api';
 import { DoctorRegistrationFormData } from '@/stores/doctorRegistrationFormStore';
+import { logger } from '@/utils/logger';
 
 export const doctorService = {
   register: async (doctorData: DoctorRegistrationFormData) => {
@@ -7,7 +8,7 @@ export const doctorService = {
       const response = await apiClient.post('/register/doctor', doctorData);
       return response.data;
     } catch (error) {
-      console.error('Erro ao registrar médico:', error);
+      logger.error('Erro ao registrar médico:', error);
       throw error;
     }
   },

--- a/mobile/services/receptorService.ts
+++ b/mobile/services/receptorService.ts
@@ -1,5 +1,6 @@
 import { apiClient } from './api';
 import axios, { AxiosError } from 'axios';
+import { logger } from '@/utils/logger';
 
 export interface ReceptorRegistrationData {
   name: string;
@@ -67,7 +68,7 @@ export const receptorService = {
       );
       return response.data;
     } catch (error) {
-      console.error('Erro ao registrar receptor:', error);
+      logger.error('Erro ao registrar receptor:', error);
 
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError<ApiValidationError>;

--- a/mobile/stores/authStore.ts
+++ b/mobile/stores/authStore.ts
@@ -6,6 +6,7 @@ import {
 } from '@/services/pushNotificationService';
 import { STORAGE_KEYS } from '@/config/storage';
 import { getErrorMessage } from '@/utils/error';
+import { logger } from '@/utils/logger';
 import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
@@ -79,7 +80,7 @@ export const useAuthStore = create<AuthStoreState>((set, get) => ({
         isAuthenticated: true,
       });
     } catch (error) {
-      console.error('Error saving session:', getErrorMessage(error));
+      logger.error('Error saving session:', getErrorMessage(error));
       set({ error: 'Failed to save session' });
     }
   },
@@ -94,7 +95,7 @@ export const useAuthStore = create<AuthStoreState>((set, get) => ({
 
       set({ token, expiresAt });
     } catch (error) {
-      console.error('Error updating access token:', getErrorMessage(error));
+      logger.error('Error updating access token:', getErrorMessage(error));
       set({ error: 'Failed to update access token' });
     }
   },
@@ -103,7 +104,7 @@ export const useAuthStore = create<AuthStoreState>((set, get) => ({
     try {
       return await SecureStore.getItemAsync(STORAGE_KEYS.REFRESH_TOKEN);
     } catch (error) {
-      console.error('Error getting refresh token:', getErrorMessage(error));
+      logger.error('Error getting refresh token:', getErrorMessage(error));
       return null;
     }
   },
@@ -133,7 +134,7 @@ export const useAuthStore = create<AuthStoreState>((set, get) => ({
         isAuthenticated: false,
       });
     } catch (error) {
-      console.error('Error logging out:', getErrorMessage(error));
+      logger.error('Error logging out:', getErrorMessage(error));
       delete api.defaults.headers.common['Authorization'];
       set({
         user: null,
@@ -171,7 +172,7 @@ export const useAuthStore = create<AuthStoreState>((set, get) => ({
       set({ user, token, refreshToken, isAuthenticated: true, isLoading: false });
       return true;
     } catch (error) {
-      console.error('Error checking authentication:', getErrorMessage(error));
+      logger.error('Error checking authentication:', getErrorMessage(error));
       set({ isLoading: false, error: 'Failed to check authentication' });
       return false;
     }
@@ -189,7 +190,7 @@ export const useAuthStore = create<AuthStoreState>((set, get) => ({
         set({ pushToken: expoPushToken });
       }
     } catch (error) {
-      console.error('Error setting up push notifications:', getErrorMessage(error));
+      logger.error('Error setting up push notifications:', getErrorMessage(error));
     }
   },
 }));

--- a/mobile/stores/doctorRegistrationFormStore.ts
+++ b/mobile/stores/doctorRegistrationFormStore.ts
@@ -2,6 +2,7 @@ import { doctorService } from '@/services/doctorService';
 import { create } from 'zustand';
 import * as Device from 'expo-device';
 import { useAuthStore } from './authStore';
+import { logger } from '@/utils/logger';
 
 export interface DoctorRegistrationFormData {
   // first step
@@ -125,7 +126,7 @@ async function getDeviceName(): Promise<string> {
 
     return deviceName || 'Dispositivo Desconhecido';
   } catch (error) {
-    console.warn('Erro ao obter nome do dispositivo:', error);
+    logger.warn('Erro ao obter nome do dispositivo:', error);
     return 'Mobile App';
   }
 }

--- a/mobile/stores/receptorRegistrationStore.ts
+++ b/mobile/stores/receptorRegistrationStore.ts
@@ -7,6 +7,7 @@ import { create } from 'zustand';
 import * as Device from 'expo-device';
 import { useAuthStore } from './authStore';
 import { cleanNumeric } from '@/utils/validation/receptorValidation';
+import { logger } from '@/utils/logger';
 
 export interface ReceptorRegistrationFormData {
   name: string;
@@ -126,7 +127,7 @@ async function getDeviceName(): Promise<string> {
 
     return deviceName || 'Dispositivo Desconhecido';
   } catch (error) {
-    console.warn('Erro ao obter nome do dispositivo:', error);
+    logger.warn('Erro ao obter nome do dispositivo:', error);
     return 'Mobile App';
   }
 }

--- a/mobile/utils/logger.ts
+++ b/mobile/utils/logger.ts
@@ -1,0 +1,40 @@
+/**
+ * Logger wrapper that only logs in development mode.
+ * Prevents console output in production builds.
+ */
+
+const isDev = __DEV__;
+
+type LogArgs = Parameters<typeof console.log>;
+
+export const logger = {
+  log: (...args: LogArgs): void => {
+    if (isDev) {
+      console.log(...args);
+    }
+  },
+
+  warn: (...args: LogArgs): void => {
+    if (isDev) {
+      console.warn(...args);
+    }
+  },
+
+  error: (...args: LogArgs): void => {
+    if (isDev) {
+      console.error(...args);
+    }
+  },
+
+  info: (...args: LogArgs): void => {
+    if (isDev) {
+      console.info(...args);
+    }
+  },
+
+  debug: (...args: LogArgs): void => {
+    if (isDev) {
+      console.debug(...args);
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- Create `utils/logger.ts` wrapper that only logs when `__DEV__` is true
- Replace all 15 console.log/error/warn calls across 7 files with logger equivalents
- Prevents debug output from appearing in production builds

## Files Changed
- **New:** `mobile/utils/logger.ts` - Logger wrapper with conditional output
- `stores/authStore.ts` - 6 console.error replaced
- `stores/receptorRegistrationStore.ts` - 1 console.warn replaced
- `stores/doctorRegistrationFormStore.ts` - 1 console.warn replaced
- `screens/DoctorRegistration/DoctorRegistrationFlow/index.tsx` - 2 calls replaced
- `services/authService.ts` - 3 console.error replaced
- `services/receptorService.ts` - 1 console.error replaced
- `services/doctorService.ts` - 1 console.error replaced

## Test plan
- [x] TypeScript types pass
- [x] All 185 tests pass
- [x] ESLint passes (pre-existing warnings only)

Closes #109