### PR TITLE
docs(mobile): create .env.local.example with documented environment variables

### DIFF
--- a/mobile/.env.local.example
+++ b/mobile/.env.local.example
@@ -1,0 +1,39 @@
+# =============================================================================
+# DoaFarma Mobile - Environment Variables
+# =============================================================================
+#
+# Copy this file to .env.local and adjust the values for your environment.
+#
+#   cp .env.local.example .env.local
+#
+# IMPORTANT: .env.local is gitignored and should NOT be committed.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# API Configuration
+# -----------------------------------------------------------------------------
+# The host where the Laravel API is running.
+#
+# Options:
+#   - Local development (Docker):
+#       - Use your machine's local IP (run `ifconfig` or `ip addr` to find it)
+#       - Example: 192.168.1.100
+#       - Do NOT use localhost/127.0.0.1 (won't work from mobile device/emulator)
+#
+#   - Android Emulator:
+#       - Use 10.0.2.2 (special alias for host machine's localhost)
+#
+#   - Production:
+#       - Use the full URL: https://doafarma-api.onrender.com
+#
+EXPO_PUBLIC_API_HOST=192.168.0.1
+
+# -----------------------------------------------------------------------------
+# Feature Flags
+# -----------------------------------------------------------------------------
+# Enable frontend validation (Zod schemas).
+# When false, validation is handled only by the backend.
+#
+# Options: true | false
+#
+EXPO_PUBLIC_ENABLE_FRONTEND_VALIDATION=false


### PR DESCRIPTION
## Summary
- Create `.env.local.example` template for mobile environment configuration
- Document `EXPO_PUBLIC_API_HOST` with options for local dev, Android emulator, and production
- Document `EXPO_PUBLIC_ENABLE_FRONTEND_VALIDATION` feature flag
- Include clear copy instructions for developers

## Why
Developers joining the project did not know they needed to create `.env.local` or what values to use. This template makes onboarding easier.

## Test plan
- [x] File is NOT gitignored (verified with `git check-ignore`)
- [x] TypeScript types pass
- [x] All tests pass

Closes #98