### PR TITLE
feat(mobile): select de cidades dinâmico com busca e cache por UF

### DIFF
--- a/mobile/components/SearchableSelect/SearchableSelect.tsx
+++ b/mobile/components/SearchableSelect/SearchableSelect.tsx
@@ -1,0 +1,184 @@
+import {
+  ActivityIndicator,
+  FlatList,
+  Modal,
+  Pressable,
+  StyleProp,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { Controller, FieldValues, UseControllerProps } from 'react-hook-form';
+import { forwardRef, useImperativeHandle, useMemo, useState } from 'react';
+import { Colors } from '@/constants/Colors';
+import { styles } from './styles';
+
+export interface SearchableSelectRef {
+  focus: () => void;
+}
+
+interface SearchableSelectProps<T extends FieldValues = FieldValues> {
+  formProps: UseControllerProps<T>;
+  placeholder: string;
+  cities: string[];
+  isLoading: boolean;
+  loadError?: string | null;
+  containerStyle?: StyleProp<ViewStyle>;
+  nextRef?: React.RefObject<{ focus: () => void } | null>;
+  error?: string;
+}
+
+/**
+ * SearchableSelect — Select com busca para listas grandes como cidades.
+ *
+ * - Unifica o comportamento entre iOS e Android via Modal com FlatList.
+ * - Exibe ActivityIndicator enquanto as opções carregam.
+ * - Filtra as opções em tempo real conforme o usuário digita.
+ * - Expõe `focus()` via ref para navegação sequencial entre campos.
+ */
+const SearchableSelect = forwardRef<SearchableSelectRef, SearchableSelectProps<any>>(
+  (
+    { formProps, placeholder, cities, isLoading, loadError, containerStyle, nextRef, error },
+    ref
+  ) => {
+    const [modalVisible, setModalVisible] = useState(false);
+    const [searchText, setSearchText] = useState('');
+    const hasError = !!error;
+    const isDisabled = isLoading || cities.length === 0;
+
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        if (!isDisabled) openModal();
+      },
+    }));
+
+    function openModal() {
+      setModalVisible(true);
+    }
+
+    function closeModal() {
+      setModalVisible(false);
+      setSearchText('');
+    }
+
+    const filteredCities = useMemo(() => {
+      if (!searchText) return cities;
+      const lower = searchText.toLowerCase();
+      return cities.filter((city) => city.toLowerCase().includes(lower));
+    }, [cities, searchText]);
+
+    return (
+      <View
+        style={[
+          styles.container,
+          hasError || loadError ? { marginBottom: 8 } : { marginBottom: 16 },
+          containerStyle,
+        ]}
+      >
+        <Controller
+          {...formProps}
+          render={({ field }) => (
+            <>
+              <TouchableOpacity
+                style={[
+                  styles.trigger,
+                  hasError && styles.triggerError,
+                  modalVisible && styles.triggerFocused,
+                  isDisabled && styles.triggerDisabled,
+                ]}
+                onPress={openModal}
+                disabled={isDisabled}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={field.value || placeholder}
+                accessibilityState={{ disabled: isDisabled }}
+              >
+                {isLoading ? (
+                  <View style={styles.loadingRow}>
+                    <ActivityIndicator size="small" color={Colors.yellow_green_400} />
+                    <Text style={styles.loadingText}>Carregando cidades...</Text>
+                  </View>
+                ) : (
+                  <Text style={[styles.triggerText, !field.value && styles.placeholderText]}>
+                    {field.value || placeholder}
+                  </Text>
+                )}
+              </TouchableOpacity>
+
+              <Modal
+                visible={modalVisible}
+                animationType="fade"
+                transparent
+                onRequestClose={closeModal}
+              >
+                <Pressable style={styles.modalOverlay} onPress={closeModal}>
+                  <View style={styles.modalContent}>
+                    <TextInput
+                      style={styles.searchInput}
+                      placeholder="Buscar cidade..."
+                      placeholderTextColor="#AFB2BF"
+                      value={searchText}
+                      onChangeText={setSearchText}
+                      autoFocus
+                    />
+
+                    {filteredCities.length === 0 ? (
+                      <View style={styles.emptyContainer}>
+                        <Text style={styles.emptyText}>Nenhuma cidade encontrada</Text>
+                      </View>
+                    ) : (
+                      <FlatList
+                        data={filteredCities}
+                        keyExtractor={(item) => item}
+                        keyboardShouldPersistTaps="handled"
+                        renderItem={({ item }) => {
+                          const isSelected = field.value === item;
+                          return (
+                            <TouchableOpacity
+                              style={styles.optionItem}
+                              onPress={() => {
+                                field.onChange(item);
+                                closeModal();
+                                if (nextRef) nextRef.current?.focus();
+                              }}
+                              accessibilityRole="button"
+                              accessibilityLabel={`Selecionar cidade: ${item}`}
+                            >
+                              <Text
+                                style={[styles.optionText, isSelected && styles.optionTextSelected]}
+                              >
+                                {item}
+                              </Text>
+                            </TouchableOpacity>
+                          );
+                        }}
+                      />
+                    )}
+
+                    <TouchableOpacity
+                      style={styles.cancelButton}
+                      onPress={closeModal}
+                      accessibilityRole="button"
+                      accessibilityLabel="Cancelar seleção"
+                    >
+                      <Text style={styles.cancelText}>Cancelar</Text>
+                    </TouchableOpacity>
+                  </View>
+                </Pressable>
+              </Modal>
+            </>
+          )}
+        />
+
+        {hasError && <Text style={styles.errorText}>{error}</Text>}
+        {!hasError && loadError && <Text style={styles.loadErrorText}>{loadError}</Text>}
+      </View>
+    );
+  }
+);
+
+SearchableSelect.displayName = 'SearchableSelect';
+
+export { SearchableSelect };

--- a/mobile/components/SearchableSelect/index.ts
+++ b/mobile/components/SearchableSelect/index.ts
@@ -1,0 +1,2 @@
+export { SearchableSelect } from './SearchableSelect';
+export type { SearchableSelectRef } from './SearchableSelect';

--- a/mobile/components/SearchableSelect/styles.ts
+++ b/mobile/components/SearchableSelect/styles.ts
@@ -1,0 +1,129 @@
+import { Colors } from '@/constants/Colors';
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+
+  trigger: {
+    justifyContent: 'center',
+    width: '100%',
+    height: 48,
+    borderRadius: 10,
+    backgroundColor: '#F7F7F7',
+  },
+
+  triggerFocused: {
+    borderWidth: 1,
+    borderColor: Colors.yellow_green_400,
+  },
+
+  triggerError: {
+    borderWidth: 1,
+    borderColor: '#E53935',
+  },
+
+  triggerDisabled: {
+    opacity: 0.5,
+  },
+
+  triggerText: {
+    fontSize: 16,
+    color: '#222',
+    paddingVertical: 12,
+    paddingLeft: 16,
+  },
+
+  placeholderText: {
+    color: '#AFB2BF',
+  },
+
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 16,
+    gap: 8,
+  },
+
+  loadingText: {
+    fontSize: 14,
+    color: '#AFB2BF',
+  },
+
+  errorText: {
+    color: '#E53935',
+    fontSize: 12,
+    marginTop: 2,
+    marginLeft: 4,
+  },
+
+  loadErrorText: {
+    color: '#E53935',
+    fontSize: 12,
+    marginTop: 2,
+    marginLeft: 4,
+  },
+
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: Colors.overlay,
+    justifyContent: 'center',
+    padding: 24,
+  },
+
+  modalContent: {
+    backgroundColor: Colors.white,
+    borderRadius: 12,
+    maxHeight: '70%',
+    overflow: 'hidden',
+  },
+
+  searchInput: {
+    height: 48,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+    paddingHorizontal: 16,
+    fontSize: 16,
+    color: '#222',
+  },
+
+  optionItem: {
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+
+  optionText: {
+    fontSize: 16,
+    color: '#222',
+  },
+
+  optionTextSelected: {
+    color: Colors.yellow_green_500,
+    fontWeight: 'bold',
+  },
+
+  emptyContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+
+  emptyText: {
+    fontSize: 14,
+    color: '#AFB2BF',
+  },
+
+  cancelButton: {
+    paddingVertical: 16,
+    alignItems: 'center',
+    borderTopWidth: 1,
+    borderTopColor: '#eee',
+  },
+
+  cancelText: {
+    color: '#AFB2BF',
+    fontSize: 14,
+  },
+});

--- a/mobile/components/Select/select.tsx
+++ b/mobile/components/Select/select.tsx
@@ -9,7 +9,6 @@ import {
   Pressable,
   StyleProp,
   Text,
-  TextInput,
   TextStyle,
   TouchableOpacity,
   View,
@@ -25,7 +24,7 @@ interface SelectProps<T extends FieldValues = FieldValues> {
   containerStyle?: StyleProp<ViewStyle>;
   selectViewStyle?: StyleProp<ViewStyle>;
   selectStyle?: StyleProp<TextStyle>;
-  nextRef?: React.RefObject<TextInput | Picker<string | number> | null>;
+  nextRef?: React.RefObject<{ focus: () => void } | null>;
   error?: string;
 }
 

--- a/mobile/hooks/useCitiesByState.ts
+++ b/mobile/hooks/useCitiesByState.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+
+const citiesCache = new Map<string, string[]>();
+
+const IBGE_MUNICIPALITIES_URL = 'https://servicodados.ibge.gov.br/api/v1/localidades/estados';
+
+interface IbgeMunicipality {
+  id: number;
+  nome: string;
+}
+
+export interface UseCitiesByStateResult {
+  cities: string[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useCitiesByState(uf: string | null): UseCitiesByStateResult {
+  const [cities, setCities] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!uf) {
+      setCities([]);
+      setError(null);
+      return;
+    }
+
+    if (citiesCache.has(uf)) {
+      setCities(citiesCache.get(uf)!);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+
+    fetch(`${IBGE_MUNICIPALITIES_URL}/${uf}/municipios`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Resposta inválida da API');
+        return res.json() as Promise<IbgeMunicipality[]>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const names = data.map((m) => m.nome).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+        citiesCache.set(uf, names);
+        setCities(names);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError('Erro ao carregar cidades. Tente novamente.');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [uf]);
+
+  return { cities, isLoading, error };
+}

--- a/mobile/screens/DoctorRegistration/steps/DoctorAddressStep/index.tsx
+++ b/mobile/screens/DoctorRegistration/steps/DoctorAddressStep/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { View, TextInput } from 'react-native';
 import { Input } from '@/components/Input';
 import PrimaryButton from '@/components/PrimaryButton';
@@ -8,11 +8,13 @@ import { Title } from '@/components/Title';
 import { Caption } from '@/components/Caption';
 import { InputRow } from '@/components/InputRow';
 import { Select, SelectItem } from '@/components/Select';
+import { SearchableSelect, SearchableSelectRef } from '@/components/SearchableSelect';
 import { Picker } from '@react-native-picker/picker';
 import { DoctorRegistrationFormData } from '@/stores/doctorRegistrationFormStore';
 import { BRAZILIAN_STATES } from '@/constants/BrazilianStates';
 import { z } from 'zod';
 import { useFeatureForm } from '@/hooks/useFeatureForm';
+import { useCitiesByState } from '@/hooks/useCitiesByState';
 
 interface DoctorAddressStepProps {
   onSubmit: (
@@ -62,9 +64,18 @@ export function DoctorAddressStep({ onSubmit }: DoctorAddressStepProps) {
     handleSubmit,
     formState: { errors },
     setError,
+    watch,
+    setValue,
   } = useFeatureForm<DoctorAddressFormData>({
     schema: doctorAddressSchema,
   });
+
+  const selectedUf = watch('addresses.0.uf');
+  const { cities, isLoading, error: citiesError } = useCitiesByState(selectedUf || null);
+
+  useEffect(() => {
+    setValue('addresses.0.city', '');
+  }, [selectedUf, setValue]);
 
   async function handleFinishRegistration(data: DoctorAddressFormData) {
     await onSubmit(data, setError);
@@ -72,7 +83,7 @@ export function DoctorAddressStep({ onSubmit }: DoctorAddressStepProps) {
 
   const cepRef = useRef<TextInput>(null);
   const ufRef = useRef<Picker<string | number>>(null);
-  const cityRef = useRef<Picker<string | number>>(null);
+  const cityRef = useRef<SearchableSelectRef | null>(null);
   const neighborhoodRef = useRef<TextInput>(null);
   const streetRef = useRef<TextInput>(null);
   const numberRef = useRef<TextInput>(null);
@@ -130,23 +141,20 @@ export function DoctorAddressStep({ onSubmit }: DoctorAddressStepProps) {
               <SelectItem key={state.value} label={state.label} value={state.value} />
             ))}
           </Select>
-          <Select
+          <SearchableSelect
             ref={cityRef}
             formProps={{
               name: 'addresses[0].city',
               control: control,
             }}
-            selectProps={{
-              placeholder: 'Cidade',
-            }}
+            placeholder="Cidade"
+            cities={cities}
+            isLoading={isLoading}
+            loadError={citiesError}
             error={errors.addresses?.[0]?.city?.message}
             containerStyle={{ flex: 1 }}
             nextRef={neighborhoodRef}
-          >
-            <SelectItem label="Rio Branco" value="Rio Branco" />
-            <SelectItem label="Maceió" value="Maceió" />
-            <SelectItem label="Macapá" value="Macapá" />
-          </Select>
+          />
         </InputRow>
         <Input
           ref={neighborhoodRef}


### PR DESCRIPTION
## Contexto

Closes #97

O select de cidade estava hardcoded com 3 cidades irrelevantes. A UX era quebrada: o usuário não conseguia selecionar sua cidade real, e o campo não dependia do estado escolhido.

## O que foi feito

### `hooks/useCitiesByState.ts` (novo)
- Busca municípios da API pública do IBGE (`/api/v1/localidades/estados/{UF}/municipios`)
- Cache em `Map` estático de módulo: a primeira requisição por UF é armazenada; seleções subsequentes do mesmo estado não fazem nova chamada
- Cancela requisições em voo quando o componente desmonta ou o UF muda
- Retorna `{ cities, isLoading, error }`

### `components/SearchableSelect/` (novo)
- Modal unificado para iOS e Android (sem Picker nativo, que não suporta busca)
- `TextInput` com `autoFocus` para filtragem em tempo real da lista de cidades
- `ActivityIndicator` enquanto o IBGE responde
- Estado desabilitado quando nenhum estado foi selecionado
- `forwardRef` expondo `focus()` para navegação sequencial entre campos do formulário
- Exibe erro de carregamento caso a API IBGE falhe

### `components/Select/select.tsx` (ajuste de tipo)
- Widening do tipo `nextRef` de `RefObject<TextInput | Picker>` para `RefObject<{ focus: () => void }>` — retrocompatível, sem mudança comportamental

### `screens/DoctorRegistration/steps/DoctorAddressStep/index.tsx` (integração)
- `watch('addresses.0.uf')` observa o estado selecionado
- `useEffect` reseta o campo cidade sempre que o estado muda
- Substitui `<Select>` hardcoded por `<SearchableSelect>` com dados dinâmicos

## Fluxo resultante

1. Usuário abre a tela → campo "Cidade" desabilitado
2. Seleciona um estado → spinner "Carregando cidades..."
3. IBGE responde → modal de busca disponível
4. Digita "Belo..." → lista filtra para "Belo Horizonte", etc.
5. Muda de estado → cidade reseta, nova lista carrega (ou usa cache se já visitado)

## Checklist de qualidade

- [x] ESLint: 0 erros (warnings pré-existentes, não relacionados)
- [x] TypeScript: sem erros
- [x] Testes: 185 passando, 0 falhas
- [x] Pre-commit hook: passou sem intervenção