### PR TITLE
feat(mobile): offline detection with NetInfo, banner and API guard

### DIFF
--- a/mobile/__tests__/stores/networkStore.test.ts
+++ b/mobile/__tests__/stores/networkStore.test.ts
@@ -1,0 +1,117 @@
+import { useNetworkStore, onReconnect } from '@/stores/networkStore';
+
+describe('networkStore', () => {
+  beforeEach(() => {
+    // Reset store to initial state before each test
+    useNetworkStore.setState({ isConnected: true, isInternetReachable: null });
+  });
+
+  describe('initial state', () => {
+    it('starts with isConnected: true (optimistic)', () => {
+      const { isConnected } = useNetworkStore.getState();
+      expect(isConnected).toBe(true);
+    });
+
+    it('starts with isInternetReachable: null', () => {
+      const { isInternetReachable } = useNetworkStore.getState();
+      expect(isInternetReachable).toBeNull();
+    });
+  });
+
+  describe('setNetworkState', () => {
+    it('updates isConnected and isInternetReachable', () => {
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(false, false);
+
+      const state = useNetworkStore.getState();
+      expect(state.isConnected).toBe(false);
+      expect(state.isInternetReachable).toBe(false);
+    });
+
+    it('updates to connected with reachable internet', () => {
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(false, false);
+      setNetworkState(true, true);
+
+      const state = useNetworkStore.getState();
+      expect(state.isConnected).toBe(true);
+      expect(state.isInternetReachable).toBe(true);
+    });
+
+    it('handles null isInternetReachable', () => {
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(true, null);
+
+      const state = useNetworkStore.getState();
+      expect(state.isInternetReachable).toBeNull();
+    });
+  });
+
+  describe('onReconnect callbacks', () => {
+    it('fires callback on offline → online transition', () => {
+      const callback = jest.fn();
+      const unsubscribe = onReconnect(callback);
+
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(false, false); // go offline
+      setNetworkState(true, true); // go back online
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+    });
+
+    it('does not fire callback if already connected', () => {
+      const callback = jest.fn();
+      const unsubscribe = onReconnect(callback);
+
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(true, true); // already connected → connected
+
+      expect(callback).not.toHaveBeenCalled();
+
+      unsubscribe();
+    });
+
+    it('does not fire callback when going offline', () => {
+      const callback = jest.fn();
+      const unsubscribe = onReconnect(callback);
+
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(false, false); // go offline
+
+      expect(callback).not.toHaveBeenCalled();
+
+      unsubscribe();
+    });
+
+    it('unsubscribe removes callback so it is not called again', () => {
+      const callback = jest.fn();
+      const unsubscribe = onReconnect(callback);
+
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(false, false); // go offline
+      unsubscribe(); // remove callback
+      setNetworkState(true, true); // go back online
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('fires multiple registered callbacks on reconnect', () => {
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      const unsub1 = onReconnect(cb1);
+      const unsub2 = onReconnect(cb2);
+
+      const { setNetworkState } = useNetworkStore.getState();
+      setNetworkState(false, false);
+      setNetworkState(true, true);
+
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).toHaveBeenCalledTimes(1);
+
+      unsub1();
+      unsub2();
+    });
+  });
+});

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -11,6 +11,8 @@ import {
 } from '@expo-google-fonts/roboto';
 import { StatusBar } from 'expo-status-bar';
 import { useAuthStore } from '@/stores/authStore';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import OfflineBanner from '@/components/OfflineBanner';
 import Toast from 'react-native-toast-message';
 import type { Subscription } from 'expo-notifications';
 import {
@@ -39,6 +41,7 @@ export default function RootLayout() {
   });
 
   const checkAuth = useAuthStore((state) => state.checkAuth);
+  useNetworkStatus();
   const notificationListener = useRef<Subscription | null>(null);
   const responseListener = useRef<Subscription | null>(null);
 
@@ -112,6 +115,7 @@ function RootLayoutNav() {
         }}
       />
       <StatusBar style="auto" />
+      <OfflineBanner />
       <Toast />
     </>
   );

--- a/mobile/components/OfflineBanner/index.tsx
+++ b/mobile/components/OfflineBanner/index.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Toast from 'react-native-toast-message';
+import { useNetworkStore } from '@/stores/networkStore';
+import { styles } from './styles';
+
+export default function OfflineBanner() {
+  const isConnected = useNetworkStore((state) => state.isConnected);
+  const wasOfflineRef = useRef(false);
+
+  useEffect(() => {
+    if (!isConnected) {
+      wasOfflineRef.current = true;
+    } else if (wasOfflineRef.current) {
+      // Only show reconnect toast if the device was previously offline
+      Toast.show({
+        type: 'success',
+        text1: 'Você está online novamente',
+        visibilityTime: 3000,
+        autoHide: true,
+      });
+      wasOfflineRef.current = false;
+    }
+  }, [isConnected]);
+
+  if (isConnected) return null;
+
+  return (
+    <View style={styles.banner}>
+      <Ionicons name="wifi-outline" size={16} color="#fff" />
+      <Text style={styles.text}>Sem conexão com a internet</Text>
+    </View>
+  );
+}

--- a/mobile/components/OfflineBanner/styles.ts
+++ b/mobile/components/OfflineBanner/styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from 'react-native';
+import { Colors } from '@/constants/Colors';
+
+export const styles = StyleSheet.create({
+  banner: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: Colors.red_600,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    zIndex: 9999,
+  },
+  text: {
+    color: Colors.white,
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});

--- a/mobile/components/PrimaryButton/index.tsx
+++ b/mobile/components/PrimaryButton/index.tsx
@@ -1,20 +1,34 @@
 import { Pressable, Text, PressableProps } from 'react-native';
 import { styles } from './styles';
 import { a11y } from '@/utils/accessibility';
+import { useNetworkStore } from '@/stores/networkStore';
 
 interface PrimaryButtonProps extends PressableProps {
   label: string;
+  disableWhenOffline?: boolean;
 }
 
-export default function PrimaryButton({ label, disabled, ...props }: PrimaryButtonProps) {
+export default function PrimaryButton({
+  label,
+  disabled,
+  disableWhenOffline = false,
+  ...props
+}: PrimaryButtonProps) {
+  const isConnected = useNetworkStore((state) => state.isConnected);
+  const isDisabled = disabled || (disableWhenOffline && !isConnected);
+
   return (
     <Pressable
-      {...a11y.button(label, disabled ?? undefined)}
-      disabled={disabled}
+      {...a11y.button(label, isDisabled ?? undefined)}
+      disabled={isDisabled}
       {...props}
-      style={({ pressed }) => [styles.buttonPrimary, pressed && styles.buttonHover]}
+      style={({ pressed }) => [
+        styles.buttonPrimary,
+        pressed && styles.buttonHover,
+        isDisabled && styles.buttonDisabled,
+      ]}
     >
-      <Text style={styles.buttonText}>{label}</Text>
+      <Text style={[styles.buttonText, isDisabled && styles.buttonTextDisabled]}>{label}</Text>
     </Pressable>
   );
 }

--- a/mobile/components/PrimaryButton/styles.ts
+++ b/mobile/components/PrimaryButton/styles.ts
@@ -24,4 +24,10 @@ export const styles = StyleSheet.create({
     fontFamily: fontFamily.bold,
     lineHeight: 56,
   },
+
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+
+  buttonTextDisabled: {},
 });

--- a/mobile/components/SecondaryButton/index.tsx
+++ b/mobile/components/SecondaryButton/index.tsx
@@ -1,21 +1,41 @@
 import { Pressable, Text, PressableProps } from 'react-native';
 import { styles } from './styles';
 import { a11y } from '@/utils/accessibility';
+import { useNetworkStore } from '@/stores/networkStore';
 
 interface SecondaryButtonProps extends PressableProps {
   label: string;
+  disableWhenOffline?: boolean;
 }
 
-export default function SecondaryButton({ label, disabled, ...props }: SecondaryButtonProps) {
+export default function SecondaryButton({
+  label,
+  disabled,
+  disableWhenOffline = false,
+  ...props
+}: SecondaryButtonProps) {
+  const isConnected = useNetworkStore((state) => state.isConnected);
+  const isDisabled = disabled || (disableWhenOffline && !isConnected);
+
   return (
     <Pressable
-      {...a11y.button(label, disabled ?? undefined)}
-      disabled={disabled}
+      {...a11y.button(label, isDisabled ?? undefined)}
+      disabled={isDisabled}
       {...props}
-      style={({ pressed }) => [styles.buttonSecondary, pressed && styles.buttonHoverSecondary]}
+      style={({ pressed }) => [
+        styles.buttonSecondary,
+        pressed && styles.buttonHoverSecondary,
+        isDisabled && styles.buttonDisabled,
+      ]}
     >
       {({ pressed }) => (
-        <Text style={[styles.buttonTextSecondary, pressed && styles.buttonTextSecondaryHover]}>
+        <Text
+          style={[
+            styles.buttonTextSecondary,
+            pressed && styles.buttonTextSecondaryHover,
+            isDisabled && styles.buttonTextDisabled,
+          ]}
+        >
           {label}
         </Text>
       )}

--- a/mobile/components/SecondaryButton/styles.ts
+++ b/mobile/components/SecondaryButton/styles.ts
@@ -27,4 +27,10 @@ export const styles = StyleSheet.create({
   buttonTextSecondaryHover: {
     color: Colors.yellow_green_500,
   },
+
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+
+  buttonTextDisabled: {},
 });

--- a/mobile/hooks/useNetworkStatus.ts
+++ b/mobile/hooks/useNetworkStatus.ts
@@ -1,0 +1,26 @@
+import NetInfo from '@react-native-community/netinfo';
+import { useEffect } from 'react';
+import { useNetworkStore } from '@/stores/networkStore';
+
+/**
+ * Initializes the NetInfo listener and syncs network state to the store.
+ * Call this ONCE at the root of the app (app/_layout.tsx).
+ * Components that need network state should read directly from useNetworkStore.
+ */
+export function useNetworkStatus() {
+  const setNetworkState = useNetworkStore((state) => state.setNetworkState);
+
+  useEffect(() => {
+    // Get initial state (async)
+    NetInfo.fetch().then((state) => {
+      setNetworkState(state.isConnected ?? false, state.isInternetReachable);
+    });
+
+    // Continuous listener
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setNetworkState(state.isConnected ?? false, state.isInternetReachable);
+    });
+
+    return unsubscribe;
+  }, [setNetworkState]);
+}

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -32,6 +32,12 @@ jest.mock('react-native-toast-message', () => ({
   hide: jest.fn(),
 }));
 
+// Mock @react-native-community/netinfo
+jest.mock('@react-native-community/netinfo', () => ({
+  fetch: jest.fn().mockResolvedValue({ isConnected: true, isInternetReachable: true }),
+  addEventListener: jest.fn().mockReturnValue(jest.fn()), // returns unsubscribe fn
+}));
+
 // Mock push notification service
 jest.mock('@/services/pushNotificationService', () => ({
   registerForPushNotificationsAsync: jest.fn(),

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,6 +13,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@hookform/resolvers": "^4.1.3",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/netinfo": "^12.0.1",
         "@react-native-picker/picker": "2.11.1",
         "@react-navigation/native": "^7.1.0",
         "@testing-library/react-native": "^13.2.0",
@@ -3152,6 +3153,16 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-12.0.1.tgz",
+      "integrity": "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native-picker/picker": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -38,6 +38,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@hookform/resolvers": "^4.1.3",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/netinfo": "^12.0.1",
     "@react-native-picker/picker": "2.11.1",
     "@react-navigation/native": "^7.1.0",
     "@testing-library/react-native": "^13.2.0",

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from '@/stores/authStore';
+import { useNetworkStore } from '@/stores/networkStore';
 import { STORAGE_KEYS } from '@/config/storage';
 import { API_ENDPOINTS } from '@/config/endpoints';
 import * as SecureStore from 'expo-secure-store';
@@ -59,6 +60,13 @@ function processQueue(error: unknown, token: string | null = null): void {
 
 api.interceptors.request.use(
   async (config) => {
+    const { isConnected } = useNetworkStore.getState();
+    if (!isConnected) {
+      const error = new Error('Você está sem conexão com a internet.');
+      Object.assign(error, { isNetworkError: true, isOfflineError: true });
+      return Promise.reject(error);
+    }
+
     if (config.headers.Authorization) {
       return config;
     }

--- a/mobile/stores/networkStore.ts
+++ b/mobile/stores/networkStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+// Reconnect callbacks are module-level (outside reactive state)
+// since they don't need to trigger re-renders
+const reconnectCallbacks = new Set<() => void>();
+
+interface NetworkStoreState {
+  isConnected: boolean;
+  isInternetReachable: boolean | null;
+  setNetworkState: (isConnected: boolean, isInternetReachable: boolean | null) => void;
+}
+
+export const useNetworkStore = create<NetworkStoreState>((set, get) => ({
+  isConnected: true, // optimistic: assume connected until first check
+  isInternetReachable: null,
+
+  setNetworkState: (isConnected, isInternetReachable) => {
+    const wasConnected = get().isConnected;
+    set({ isConnected, isInternetReachable });
+
+    // offline → online transition: fire retry callbacks
+    if (!wasConnected && isConnected) {
+      reconnectCallbacks.forEach((cb) => {
+        try {
+          cb();
+        } catch {}
+      });
+    }
+  },
+}));
+
+/**
+ * Registers a callback to execute when connection is restored.
+ * Returns an unsubscribe function.
+ */
+export function onReconnect(callback: () => void): () => void {
+  reconnectCallbacks.add(callback);
+  return () => reconnectCallbacks.delete(callback);
+}


### PR DESCRIPTION
## Summary

- Add `networkStore` (Zustand) to track `isConnected`/`isInternetReachable` globally with an `onReconnect` callback utility
- Add `useNetworkStatus` hook that initializes a NetInfo listener at the app root and syncs state to the store
- Add `OfflineBanner` component: persistent red banner at the bottom of the screen when offline; success toast on reconnect
- Add offline guard to the API request interceptor — rejects requests immediately with `isOfflineError: true` instead of letting them time out
- Add opt-in `disableWhenOffline` prop to `PrimaryButton` and `SecondaryButton` (default `false` — no breaking changes)

Closes #95, closes #102 (duplicate)

## Test plan

- [ ] 10 unit tests for `networkStore` (state transitions, callbacks, unsubscribe)
- [ ] All 14 test suites pass (195 tests)
- [ ] TypeScript: 0 errors
- [ ] ESLint: 0 new warnings
- [ ] Manual: open app with internet → normal behavior
- [ ] Manual: disable WiFi/data → red banner appears at bottom; buttons with `disableWhenOffline={true}` disabled; API requests fail immediately with clear message
- [ ] Manual: re-enable internet → banner disappears; green toast "Você está online novamente"