### PR TITLE
refactor(mobile): replace any with typed ApiError and getErrorMessage (#110)

### DIFF
--- a/mobile/app/(auth)/medication-appointments/index.tsx
+++ b/mobile/app/(auth)/medication-appointments/index.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
 } from 'react-native';
 import { toast } from '@/utils/toast';
+import { getErrorMessage } from '@/types/errors';
 import { useMedicationAppointmentStore } from '@/stores/medicationAppointmentStore';
 import { MedicationAppointmentCard } from '@/components/MedicationAppointmentCard';
 import { FilterButton } from '@/components/FilterButton';
@@ -53,8 +54,8 @@ export default function DoctorReceivedAppointmentsScreen() {
             try {
               await acceptAppointment(appointment.id, true);
               toast.success('Agendamento confirmado!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível aceitar o agendamento.');
+            } catch (err: unknown) {
+              Alert.alert('Erro', getErrorMessage(err, 'Não foi possível aceitar o agendamento.'));
             }
           },
         },
@@ -69,7 +70,7 @@ export default function DoctorReceivedAppointmentsScreen() {
     try {
       await counterProposeAppointment(appointmentId, data, true);
       toast.success('Contraproposta enviada!');
-    } catch (err: any) {
+    } catch (err: unknown) {
       throw err; // Let the modal handle the error display
     }
   };
@@ -86,8 +87,8 @@ export default function DoctorReceivedAppointmentsScreen() {
             try {
               await confirmDeliveryDoctor(appointment.id);
               toast.success('Entrega confirmada com sucesso!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível confirmar a entrega.');
+            } catch (err: unknown) {
+              Alert.alert('Erro', getErrorMessage(err, 'Não foi possível confirmar a entrega.'));
             }
           },
         },

--- a/mobile/app/(auth)/medication-offerings/create.tsx
+++ b/mobile/app/(auth)/medication-offerings/create.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { View, StyleSheet, Alert, TextInput } from 'react-native';
 import { toast } from '@/utils/toast';
+import { getErrorMessage } from '@/types/errors';
 import { useRouter } from 'expo-router';
 import { useMedicationOfferingStore } from '@/stores/medicationOfferingStore';
 import { Title } from '@/components/Title';
@@ -47,7 +48,7 @@ export default function CreateMedicationOfferingScreen() {
     try {
       const response = await api.get('/v1/drugs');
       setDrugs(response.data.data);
-    } catch (error) {
+    } catch {
       Alert.alert('Erro', 'Erro ao carregar lista de medicamentos');
     } finally {
       setLoadingDrugs(false);
@@ -65,10 +66,10 @@ export default function CreateMedicationOfferingScreen() {
 
       toast.success('Oferta de medicamento criada com sucesso!');
       router.back();
-    } catch (error: any) {
+    } catch (error: unknown) {
       Alert.alert(
         'Erro ao criar oferta',
-        error.message || 'Ocorreu um erro inesperado. Tente novamente.',
+        getErrorMessage(error, 'Ocorreu um erro inesperado. Tente novamente.'),
         [{ text: 'OK' }]
       );
     }

--- a/mobile/app/(auth)/medication-offerings/edit/[id].tsx
+++ b/mobile/app/(auth)/medication-offerings/edit/[id].tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { View, StyleSheet, Alert, TextInput, ActivityIndicator } from 'react-native';
 import { toast } from '@/utils/toast';
+import { getErrorMessage } from '@/types/errors';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useMedicationOfferingStore } from '@/stores/medicationOfferingStore';
 import { Title } from '@/components/Title';
@@ -52,7 +53,7 @@ export default function EditMedicationOfferingScreen() {
     try {
       const response = await api.get('/v1/drugs');
       setDrugs(response.data.data);
-    } catch (error) {
+    } catch {
       Alert.alert('Erro', 'Erro ao carregar lista de medicamentos');
     } finally {
       setLoadingDrugs(false);
@@ -69,8 +70,8 @@ export default function EditMedicationOfferingScreen() {
         expires_at: convertDateFromAPI(offeringData.expires_at),
         quantity: offeringData.quantity.toString(),
       });
-    } catch (error: any) {
-      Alert.alert('Erro', error.message || 'Erro ao carregar dados da oferta', [
+    } catch (error: unknown) {
+      Alert.alert('Erro', getErrorMessage(error, 'Erro ao carregar dados da oferta'), [
         { text: 'OK', onPress: () => router.back() },
       ]);
     } finally {
@@ -93,10 +94,10 @@ export default function EditMedicationOfferingScreen() {
 
       toast.success('Oferta de medicamento atualizada com sucesso!');
       router.back();
-    } catch (error: any) {
+    } catch (error: unknown) {
       Alert.alert(
         'Erro ao atualizar oferta',
-        error.message || 'Ocorreu um erro inesperado. Tente novamente.',
+        getErrorMessage(error, 'Ocorreu um erro inesperado. Tente novamente.'),
         [{ text: 'OK' }]
       );
     }

--- a/mobile/app/(auth)/medication-offerings/index.tsx
+++ b/mobile/app/(auth)/medication-offerings/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
+import { getErrorMessage } from '@/types/errors';
 import { View, StyleSheet, FlatList, Alert } from 'react-native';
 import { toast } from '@/utils/toast';
 import { useRouter } from 'expo-router';
@@ -34,10 +35,10 @@ export default function MedicationOfferingsScreen() {
             try {
               await deleteOffering(id);
               toast.success('Oferta excluída com sucesso!');
-            } catch (error: any) {
+            } catch (error: unknown) {
               Alert.alert(
                 'Erro ao excluir',
-                error.message || 'Não foi possível excluir a oferta. Tente novamente.'
+                getErrorMessage(error, 'Não foi possível excluir a oferta. Tente novamente.')
               );
             }
           },

--- a/mobile/app/(auth)/medication-requests/index.tsx
+++ b/mobile/app/(auth)/medication-requests/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { getErrorMessage } from '@/types/errors';
 import {
   View,
   Text,
@@ -52,8 +53,11 @@ export default function DoctorReceivedRequestsScreen() {
             try {
               await confirmRequest(request.id);
               toast.success('Solicitação confirmada com sucesso!');
-            } catch (error: any) {
-              Alert.alert('Erro', error.message || 'Não foi possível confirmar a solicitação.');
+            } catch (error: unknown) {
+              Alert.alert(
+                'Erro',
+                getErrorMessage(error, 'Não foi possível confirmar a solicitação.')
+              );
             }
           },
         },
@@ -74,8 +78,11 @@ export default function DoctorReceivedRequestsScreen() {
             try {
               await rejectRequest(request.id);
               toast.success('Solicitação recusada.');
-            } catch (error: any) {
-              Alert.alert('Erro', error.message || 'Não foi possível recusar a solicitação.');
+            } catch (error: unknown) {
+              Alert.alert(
+                'Erro',
+                getErrorMessage(error, 'Não foi possível recusar a solicitação.')
+              );
             }
           },
         },

--- a/mobile/app/(auth)/receptor/(tabs)/appointments.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/appointments.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
 } from 'react-native';
 import { toast } from '@/utils/toast';
+import { getErrorMessage } from '@/types/errors';
 import { useMedicationAppointmentStore } from '@/stores/medicationAppointmentStore';
 import { MedicationAppointmentCard } from '@/components/MedicationAppointmentCard';
 import { FilterButton } from '@/components/FilterButton';
@@ -53,8 +54,8 @@ export default function ReceptorAppointmentsScreen() {
             try {
               await acceptAppointment(appointment.id, false);
               toast.success('Agendamento confirmado!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível aceitar o agendamento.');
+            } catch (err: unknown) {
+              Alert.alert('Erro', getErrorMessage(err, 'Não foi possível aceitar o agendamento.'));
             }
           },
         },
@@ -69,7 +70,7 @@ export default function ReceptorAppointmentsScreen() {
     try {
       await counterProposeAppointment(appointmentId, data, false);
       toast.success('Contraproposta enviada!');
-    } catch (err: any) {
+    } catch (err: unknown) {
       throw err; // Let the modal handle the error display
     }
   };
@@ -86,8 +87,11 @@ export default function ReceptorAppointmentsScreen() {
             try {
               await confirmDeliveryReceptor(appointment.id);
               toast.success('Recebimento confirmado com sucesso!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível confirmar o recebimento.');
+            } catch (err: unknown) {
+              Alert.alert(
+                'Erro',
+                getErrorMessage(err, 'Não foi possível confirmar o recebimento.')
+              );
             }
           },
         },

--- a/mobile/app/(auth)/receptor/offering/[id].tsx
+++ b/mobile/app/(auth)/receptor/offering/[id].tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { getErrorMessage } from '@/types/errors';
 import { View, Text, StyleSheet, ScrollView, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Colors } from '@/constants/Colors';
@@ -47,8 +48,8 @@ export default function OfferingDetailScreen() {
                   { text: 'OK', onPress: () => router.back() },
                 ]
               );
-            } catch (error: any) {
-              Alert.alert('Erro', error.message || 'Não foi possível enviar a solicitação.');
+            } catch (error: unknown) {
+              Alert.alert('Erro', getErrorMessage(error, 'Não foi possível enviar a solicitação.'));
             } finally {
               setIsRequesting(false);
             }

--- a/mobile/app/(auth)/receptor/schedule/[requestId].tsx
+++ b/mobile/app/(auth)/receptor/schedule/[requestId].tsx
@@ -11,6 +11,7 @@ import {
   Platform,
 } from 'react-native';
 import { toast } from '@/utils/toast';
+import { getErrorMessage } from '@/types/errors';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Colors } from '@/constants/Colors';
 import { ValidationMessages } from '@/constants/ValidationMessages';
@@ -77,8 +78,8 @@ export default function ScheduleAppointmentScreen() {
           onPress: () => router.back(),
         },
       ]);
-    } catch (error: any) {
-      Alert.alert('Erro', error.message || 'Não foi possível criar o agendamento.');
+    } catch (error: unknown) {
+      Alert.alert('Erro', getErrorMessage(error, 'Não foi possível criar o agendamento.'));
     }
   };
 

--- a/mobile/components/Select/select.tsx
+++ b/mobile/components/Select/select.tsx
@@ -61,10 +61,12 @@ const Select = forwardRef<Picker<string | number> | { focus: () => void } | null
     }));
 
     const options = Array.isArray(children)
-      ? children.map((child: any) => ({
-          label: child.props.label,
-          value: child.props.value,
-        }))
+      ? (children as React.ReactElement<{ label: string; value: string | number }>[]).map(
+          (child) => ({
+            label: child.props.label,
+            value: child.props.value,
+          })
+        )
       : [];
 
     if (Platform.OS === 'android') {

--- a/mobile/hooks/usePagination.ts
+++ b/mobile/hooks/usePagination.ts
@@ -71,8 +71,10 @@ export function usePagination<T>({
         setItems(response.data);
       } else {
         setItems((prev) => {
-          const existingIds = new Set(prev.map((item: any) => item.id));
-          const newItems = response.data.filter((item: any) => !existingIds.has(item.id));
+          const existingIds = new Set(prev.map((item) => (item as { id: unknown }).id));
+          const newItems = response.data.filter(
+            (item) => !existingIds.has((item as { id: unknown }).id)
+          );
           return [...prev, ...newItems];
         });
       }

--- a/mobile/screens/ReceptorRegistration/index.tsx
+++ b/mobile/screens/ReceptorRegistration/index.tsx
@@ -198,7 +198,7 @@ export function ReceptorRegistrationScreen() {
               name: 'cpf',
               control: control,
               rules: {
-                onChange: (e: any) => {
+                onChange: (e: { target: { value: string } }) => {
                   const formatted = formatCPF(e.target.value);
                   setValue('cpf', formatted);
                 },
@@ -220,7 +220,7 @@ export function ReceptorRegistrationScreen() {
               name: 'phone_number',
               control: control,
               rules: {
-                onChange: (e: any) => {
+                onChange: (e: { target: { value: string } }) => {
                   const formatted = formatPhone(e.target.value);
                   setValue('phone_number', formatted);
                 },

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -286,7 +286,7 @@ export const apiClient = {
 
   async post<T = any>(
     url: string,
-    data?: any,
+    data?: unknown,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     const result = await api.post<T>(url, data, config);
@@ -295,7 +295,7 @@ export const apiClient = {
 
   async put<T = any>(
     url: string,
-    data?: any,
+    data?: unknown,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     const result = await api.put<T>(url, data, config);
@@ -304,7 +304,7 @@ export const apiClient = {
 
   async patch<T = any>(
     url: string,
-    data?: any,
+    data?: unknown,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     const result = await api.patch<T>(url, data, config);

--- a/mobile/services/doctorRatingService.ts
+++ b/mobile/services/doctorRatingService.ts
@@ -7,7 +7,7 @@ export const doctorRatingService = {
     try {
       const response = await apiClient.post(`/v1/doctor-ratings/${appointmentId}`, data);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -16,7 +16,7 @@ export const doctorRatingService = {
     try {
       const response = await apiClient.patch(`/v1/doctor-ratings/${ratingId}`, data);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -25,7 +25,7 @@ export const doctorRatingService = {
     try {
       const response = await apiClient.get(`/v1/doctor-ratings/appointment/${appointmentId}`);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -34,7 +34,7 @@ export const doctorRatingService = {
     try {
       const response = await apiClient.get(`/v1/doctor-ratings/doctor/${doctorId}`);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -43,7 +43,7 @@ export const doctorRatingService = {
     try {
       const response = await apiClient.get('/v1/doctor-ratings/my-ratings');
       return response.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },

--- a/mobile/services/medicationAppointmentService.ts
+++ b/mobile/services/medicationAppointmentService.ts
@@ -13,7 +13,7 @@ export const medicationAppointmentService = {
     try {
       const response = await apiClient.post('/v1/medication-appointments', data);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -23,7 +23,7 @@ export const medicationAppointmentService = {
       const params = status ? { status } : {};
       const response = await apiClient.get('/v1/medication-appointments', { params });
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -33,7 +33,7 @@ export const medicationAppointmentService = {
       const params = status ? { status } : {};
       const response = await apiClient.get('/v1/medication-appointments/received', { params });
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -42,7 +42,7 @@ export const medicationAppointmentService = {
     try {
       const response = await apiClient.patch(`/v1/medication-appointments/${id}/accept`);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -57,7 +57,7 @@ export const medicationAppointmentService = {
         data
       );
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -68,7 +68,7 @@ export const medicationAppointmentService = {
         `/v1/medication-appointments/${id}/confirm-delivery-receptor`
       );
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -79,7 +79,7 @@ export const medicationAppointmentService = {
         `/v1/medication-appointments/${id}/confirm-delivery-doctor`
       );
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -88,7 +88,7 @@ export const medicationAppointmentService = {
     try {
       const response = await apiClient.get('/v1/medication-appointments/history');
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -103,7 +103,7 @@ export const medicationAppointmentService = {
         meta: response.data.meta,
         links: response.data.links,
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -112,7 +112,7 @@ export const medicationAppointmentService = {
     try {
       const response = await apiClient.get('/v1/medication-appointments/doctor-history');
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -129,7 +129,7 @@ export const medicationAppointmentService = {
         meta: response.data.meta,
         links: response.data.links,
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },

--- a/mobile/services/medicationOfferingService.ts
+++ b/mobile/services/medicationOfferingService.ts
@@ -17,7 +17,7 @@ export const medicationOfferingService = {
         },
       });
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -30,7 +30,7 @@ export const medicationOfferingService = {
         },
       });
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -39,7 +39,7 @@ export const medicationOfferingService = {
     try {
       const response = await apiClient.post('/v1/medication-offerings', data);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -48,7 +48,7 @@ export const medicationOfferingService = {
     try {
       const response = await apiClient.put(`/v1/medication-offerings/${id}`, data);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -56,7 +56,7 @@ export const medicationOfferingService = {
   delete: async (id: number): Promise<void> => {
     try {
       await apiClient.delete(`/v1/medication-offerings/${id}`);
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -67,7 +67,7 @@ export const medicationOfferingService = {
         params: { q: query },
       });
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -85,7 +85,7 @@ export const medicationOfferingService = {
         meta: response.data.meta,
         links: response.data.links,
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },

--- a/mobile/services/medicationRequestService.ts
+++ b/mobile/services/medicationRequestService.ts
@@ -11,7 +11,7 @@ export const medicationRequestService = {
     try {
       const response = await apiClient.post('/v1/medication-requests', data);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -20,7 +20,7 @@ export const medicationRequestService = {
     try {
       const response = await apiClient.get('/v1/medication-requests');
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -30,7 +30,7 @@ export const medicationRequestService = {
       const params = status ? { status } : {};
       const response = await apiClient.get('/v1/medication-requests/received', { params });
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -39,7 +39,7 @@ export const medicationRequestService = {
     try {
       const response = await apiClient.patch(`/v1/medication-requests/${id}/confirm`);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },
@@ -48,7 +48,7 @@ export const medicationRequestService = {
     try {
       const response = await apiClient.patch(`/v1/medication-requests/${id}/reject`);
       return response.data.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw new Error(extractErrorMessage(error));
     }
   },

--- a/mobile/stores/doctorRatingStore.ts
+++ b/mobile/stores/doctorRatingStore.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@/types/errors';
 import { create } from 'zustand';
 import { doctorRatingService } from '@/services/doctorRatingService';
 import { DoctorRating, CreateDoctorRatingData, RatingSummary } from '@/types/doctorRating';
@@ -42,8 +43,8 @@ export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
       const newRating = await doctorRatingService.create(appointmentId, data);
       set({ isLoading: false, error: null, currentRating: newRating });
       return newRating;
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -54,8 +55,8 @@ export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
       const updatedRating = await doctorRatingService.update(ratingId, data);
       set({ isLoading: false, error: null, currentRating: updatedRating });
       return updatedRating;
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -66,8 +67,8 @@ export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
       const rating = await doctorRatingService.getByAppointment(appointmentId);
       set({ isLoading: false, error: null, currentRating: rating });
       return rating;
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -77,8 +78,8 @@ export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
     try {
       const doctorRatings = await doctorRatingService.listByDoctor(doctorId);
       set({ doctorRatings, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -93,8 +94,8 @@ export const useDoctorRatingStore = create<DoctorRatingStoreState>((set) => ({
         isLoading: false,
         error: null,
       });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },

--- a/mobile/stores/doctorRegistrationFormStore.ts
+++ b/mobile/stores/doctorRegistrationFormStore.ts
@@ -1,4 +1,5 @@
 import { doctorService } from '@/services/doctorService';
+import { getErrorMessage } from '@/types/errors';
 import { create } from 'zustand';
 import * as Device from 'expo-device';
 import { useAuthStore } from './authStore';
@@ -38,6 +39,21 @@ interface DoctorRegistrationFormStore {
   updateDoctorRegistrationFormData: (data: Partial<DoctorRegistrationFormData>) => void;
   submitDoctorRegistrationForm: () => Promise<boolean>;
   clearValidationErrors: () => void;
+}
+
+interface ValidationError {
+  isValidationError: true;
+  validationErrors: Record<string, string[]>;
+  message: string;
+}
+
+function isValidationError(error: unknown): error is ValidationError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isValidationError' in error &&
+    (error as Record<string, unknown>).isValidationError === true
+  );
 }
 
 export const useDoctorRegistrationFormStore = create<DoctorRegistrationFormStore>((set, get) => ({
@@ -100,8 +116,8 @@ export const useDoctorRegistrationFormStore = create<DoctorRegistrationFormStore
 
       set({ isLoading: false });
       return true;
-    } catch (error: any) {
-      if (error.isValidationError) {
+    } catch (error: unknown) {
+      if (isValidationError(error)) {
         set({
           isLoading: false,
           validationErrors: error.validationErrors,
@@ -110,7 +126,7 @@ export const useDoctorRegistrationFormStore = create<DoctorRegistrationFormStore
       } else {
         set({
           isLoading: false,
-          error: error instanceof Error ? error.message : 'Erro ao cadastrar médico',
+          error: getErrorMessage(error, 'Erro ao cadastrar médico'),
         });
       }
 

--- a/mobile/stores/medicationAppointmentStore.ts
+++ b/mobile/stores/medicationAppointmentStore.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@/types/errors';
 import { create } from 'zustand';
 import { medicationAppointmentService } from '@/services/medicationAppointmentService';
 import {
@@ -54,8 +55,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
     try {
       const appointments = await medicationAppointmentService.list(status);
       set({ appointments, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -70,8 +71,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
         error: null,
       }));
       return newAppointment;
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -87,8 +88,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -98,8 +99,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
     try {
       const history = await medicationAppointmentService.listHistory();
       set({ history, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -109,8 +110,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
     try {
       const receivedAppointments = await medicationAppointmentService.listReceived(status);
       set({ receivedAppointments, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -126,8 +127,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -137,8 +138,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
     try {
       const donationHistory = await medicationAppointmentService.listDoctorHistory();
       set({ donationHistory, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -166,8 +167,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
           };
         }
       });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -199,8 +200,8 @@ export const useMedicationAppointmentStore = create<MedicationAppointmentStoreSt
           };
         }
       });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },

--- a/mobile/stores/medicationOfferingStore.ts
+++ b/mobile/stores/medicationOfferingStore.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@/types/errors';
 import { create } from 'zustand';
 import { medicationOfferingService } from '@/services/medicationOfferingService';
 import {
@@ -31,8 +32,8 @@ export const useMedicationOfferingStore = create<MedicationOfferingStoreState>((
     try {
       const offerings = await medicationOfferingService.list();
       set({ offerings, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -42,8 +43,8 @@ export const useMedicationOfferingStore = create<MedicationOfferingStoreState>((
     try {
       const offering = await medicationOfferingService.show(id);
       set({ currentOffering: offering, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -57,8 +58,8 @@ export const useMedicationOfferingStore = create<MedicationOfferingStoreState>((
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -75,8 +76,8 @@ export const useMedicationOfferingStore = create<MedicationOfferingStoreState>((
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -91,8 +92,8 @@ export const useMedicationOfferingStore = create<MedicationOfferingStoreState>((
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },

--- a/mobile/stores/medicationRequestStore.ts
+++ b/mobile/stores/medicationRequestStore.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@/types/errors';
 import { create } from 'zustand';
 import { medicationRequestService } from '@/services/medicationRequestService';
 import { MedicationRequest, MedicationRequestStatus } from '@/types/medicationRequest';
@@ -33,8 +34,8 @@ export const useMedicationRequestStore = create<MedicationRequestStoreState>((se
     try {
       const requests = await medicationRequestService.list();
       set({ requests, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -51,8 +52,8 @@ export const useMedicationRequestStore = create<MedicationRequestStoreState>((se
         error: null,
       }));
       return newRequest;
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -62,8 +63,8 @@ export const useMedicationRequestStore = create<MedicationRequestStoreState>((se
     try {
       const receivedRequests = await medicationRequestService.listReceived(status);
       set({ receivedRequests, isLoading: false, error: null });
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -79,8 +80,8 @@ export const useMedicationRequestStore = create<MedicationRequestStoreState>((se
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },
@@ -96,8 +97,8 @@ export const useMedicationRequestStore = create<MedicationRequestStoreState>((se
         isLoading: false,
         error: null,
       }));
-    } catch (error: any) {
-      set({ error: error.message, isLoading: false });
+    } catch (error: unknown) {
+      set({ error: getErrorMessage(error), isLoading: false });
       throw error;
     }
   },

--- a/mobile/types/errors.ts
+++ b/mobile/types/errors.ts
@@ -1,0 +1,24 @@
+export interface ApiError {
+  message: string;
+  errors?: Record<string, string[]>;
+  status?: number;
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  );
+}
+
+export function getErrorMessage(error: unknown, fallback = 'Ocorreu um erro inesperado'): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/mobile/utils/validation/errorHelpers.ts
+++ b/mobile/utils/validation/errorHelpers.ts
@@ -2,7 +2,7 @@ interface ValidationError {
   [field: string]: string[];
 }
 
-interface ApiError {
+interface ApiErrorShape {
   response?: {
     data?: {
       message?: string;
@@ -12,7 +12,15 @@ interface ApiError {
   message?: string;
 }
 
-export const extractErrorMessage = (error: ApiError): string => {
+function isApiErrorShape(error: unknown): error is ApiErrorShape {
+  return typeof error === 'object' && error !== null;
+}
+
+export const extractErrorMessage = (error: unknown): string => {
+  if (!isApiErrorShape(error)) {
+    return 'Erro inesperado';
+  }
+
   const responseErrors = error.response?.data?.errors;
 
   if (responseErrors && Object.keys(responseErrors).length > 0) {


### PR DESCRIPTION
## Descrição

Resolve #110 — substitui 75 ocorrências de `: any` por tipos apropriados no mobile.

## Mudanças

### Novo arquivo: `mobile/types/errors.ts`
- Interface `ApiError` com `message`, `errors` e `status`
- Type guard `isApiError(error: unknown): error is ApiError`
- Helper `getErrorMessage(error, fallback?)` — retorna a mensagem segura

### Arquivos modificados
- **21 arquivos** com `catch (error: any)` → `catch (error: unknown)`
- Services: `medicationRequestService`, `medicationOfferingService`, `doctorRatingService`, `medicationAppointmentService`
- Stores: `medicationAppointmentStore`, `medicationOfferingStore`, `doctorRatingStore`, `medicationRequestStore`, `doctorRegistrationFormStore`
- App screens: 8 arquivos em `app/(auth)/`
- `services/api.ts`: `data?: any` → `data?: unknown` em `post`, `put`, `patch`
- `hooks/usePagination.ts`: type assertion em vez de `item: any`
- `components/Select/select.tsx`: `ReactElement<{label, value}>[]` em vez de `child: any`
- `screens/ReceptorRegistration`: `{ target: { value: string } }` em vez de `e: any`
- `utils/validation/errorHelpers.ts`: `extractErrorMessage` atualizado para aceitar `unknown`

## Checklist
- [x] Zero ocorrências de `: any` restantes
- [x] TypeScript compila sem erros
- [x] ESLint sem erros
- [x] 195 testes passando