### PR TITLE
perf(mobile): add memo and useCallback to card components and screens (#101)

### DIFF
--- a/mobile/app/(auth)/medication-appointments/index.tsx
+++ b/mobile/app/(auth)/medication-appointments/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -31,79 +31,90 @@ export default function DoctorReceivedAppointmentsScreen() {
 
   const [filter, setFilter] = useState<FilterOption>('proposed');
 
-  const loadAppointments = () => {
+  const loadAppointments = useCallback(() => {
     const status = filter === 'all' ? undefined : filter;
     fetchReceivedAppointments(status);
-  };
+  }, [filter, fetchReceivedAppointments]);
 
   useEffect(() => {
     loadAppointments();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter]);
+  }, [loadAppointments]);
 
-  const handleAccept = (appointment: MedicationAppointment) => {
-    Alert.alert(
-      'Aceitar Proposta',
-      `Aceitar o agendamento para ${new Date(appointment.scheduled_date).toLocaleDateString('pt-BR')} às ${appointment.scheduled_time.substring(0, 5)}?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Aceitar',
-          onPress: async () => {
-            try {
-              await acceptAppointment(appointment.id, true);
-              toast.success('Agendamento confirmado!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível aceitar o agendamento.');
-            }
+  const handleAccept = useCallback(
+    (appointment: MedicationAppointment) => {
+      Alert.alert(
+        'Aceitar Proposta',
+        `Aceitar o agendamento para ${new Date(appointment.scheduled_date).toLocaleDateString('pt-BR')} às ${appointment.scheduled_time.substring(0, 5)}?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Aceitar',
+            onPress: async () => {
+              try {
+                await acceptAppointment(appointment.id, true);
+                toast.success('Agendamento confirmado!');
+              } catch (err: any) {
+                Alert.alert('Erro', err.message || 'Não foi possível aceitar o agendamento.');
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [acceptAppointment]
+  );
 
-  const handleCounterPropose = async (
-    appointmentId: number,
-    data: { scheduled_date: string; scheduled_time: string; address_id?: number }
-  ) => {
-    try {
-      await counterProposeAppointment(appointmentId, data, true);
-      toast.success('Contraproposta enviada!');
-    } catch (err: any) {
-      throw err; // Let the modal handle the error display
-    }
-  };
+  const handleCounterPropose = useCallback(
+    async (
+      appointmentId: number,
+      data: { scheduled_date: string; scheduled_time: string; address_id?: number }
+    ) => {
+      try {
+        await counterProposeAppointment(appointmentId, data, true);
+        toast.success('Contraproposta enviada!');
+      } catch (err: any) {
+        throw err; // Let the modal handle the error display
+      }
+    },
+    [counterProposeAppointment]
+  );
 
-  const handleConfirmDelivery = (appointment: MedicationAppointment) => {
-    Alert.alert(
-      'Confirmar Entrega',
-      `Confirmar que o medicamento "${appointment.medication_request?.medication_offering?.drug?.product_name}" foi entregue?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Confirmar',
-          onPress: async () => {
-            try {
-              await confirmDeliveryDoctor(appointment.id);
-              toast.success('Entrega confirmada com sucesso!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível confirmar a entrega.');
-            }
+  const handleConfirmDelivery = useCallback(
+    (appointment: MedicationAppointment) => {
+      Alert.alert(
+        'Confirmar Entrega',
+        `Confirmar que o medicamento "${appointment.medication_request?.medication_offering?.drug?.product_name}" foi entregue?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Confirmar',
+            onPress: async () => {
+              try {
+                await confirmDeliveryDoctor(appointment.id);
+                toast.success('Entrega confirmada com sucesso!');
+              } catch (err: any) {
+                Alert.alert('Erro', err.message || 'Não foi possível confirmar a entrega.');
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [confirmDeliveryDoctor]
+  );
 
-  const renderItem = ({ item }: { item: MedicationAppointment }) => (
-    <MedicationAppointmentCard
-      appointment={item}
-      variant="doctor"
-      onConfirmDelivery={() => handleConfirmDelivery(item)}
-      onAccept={() => handleAccept(item)}
-      onCounterPropose={(data) => handleCounterPropose(item.id, data)}
-      doctorAddresses={[]} // TODO: Pass doctor's addresses from user store
-    />
+  const renderItem = useCallback(
+    ({ item }: { item: MedicationAppointment }) => (
+      <MedicationAppointmentCard
+        appointment={item}
+        variant="doctor"
+        onConfirmDelivery={() => handleConfirmDelivery(item)}
+        onAccept={() => handleAccept(item)}
+        onCounterPropose={(data) => handleCounterPropose(item.id, data)}
+        doctorAddresses={[]} // TODO: Pass doctor's addresses from user store
+      />
+    ),
+    [handleConfirmDelivery, handleAccept, handleCounterPropose]
   );
 
   const renderEmpty = () => {

--- a/mobile/app/(auth)/medication-offerings/index.tsx
+++ b/mobile/app/(auth)/medication-offerings/index.tsx
@@ -21,41 +21,50 @@ export default function MedicationOfferingsScreen() {
     fetchOfferingsCallback();
   }, [fetchOfferingsCallback]);
 
-  const handleDelete = async (id: number, drugName: string) => {
-    Alert.alert(
-      'Confirmar exclusão',
-      `Tem certeza que deseja excluir a oferta do medicamento "${drugName}"?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Excluir',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await deleteOffering(id);
-              toast.success('Oferta excluída com sucesso!');
-            } catch (error: any) {
-              Alert.alert(
-                'Erro ao excluir',
-                error.message || 'Não foi possível excluir a oferta. Tente novamente.'
-              );
-            }
+  const handleDelete = useCallback(
+    async (id: number, drugName: string) => {
+      Alert.alert(
+        'Confirmar exclusão',
+        `Tem certeza que deseja excluir a oferta do medicamento "${drugName}"?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Excluir',
+            style: 'destructive',
+            onPress: async () => {
+              try {
+                await deleteOffering(id);
+                toast.success('Oferta excluída com sucesso!');
+              } catch (error: any) {
+                Alert.alert(
+                  'Erro ao excluir',
+                  error.message || 'Não foi possível excluir a oferta. Tente novamente.'
+                );
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [deleteOffering]
+  );
 
-  const handleEdit = (offering: MedicationOffering) => {
-    router.push(`/(auth)/medication-offerings/edit/${offering.id}`);
-  };
+  const handleEdit = useCallback(
+    (offering: MedicationOffering) => {
+      router.push(`/(auth)/medication-offerings/edit/${offering.id}`);
+    },
+    [router]
+  );
 
-  const renderOffering = ({ item }: { item: MedicationOffering }) => (
-    <MedicationOfferingCard
-      offering={item}
-      onEdit={() => handleEdit(item)}
-      onDelete={() => handleDelete(item.id, item.drug?.product_name || 'Medicamento')}
-    />
+  const renderOffering = useCallback(
+    ({ item }: { item: MedicationOffering }) => (
+      <MedicationOfferingCard
+        offering={item}
+        onEdit={() => handleEdit(item)}
+        onDelete={() => handleDelete(item.id, item.drug?.product_name || 'Medicamento')}
+      />
+    ),
+    [handleEdit, handleDelete]
   );
 
   return (

--- a/mobile/app/(auth)/medication-requests/index.tsx
+++ b/mobile/app/(auth)/medication-requests/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -30,66 +30,74 @@ export default function DoctorReceivedRequestsScreen() {
 
   const [filter, setFilter] = useState<FilterOption>('pending');
 
-  const loadRequests = () => {
+  const loadRequests = useCallback(() => {
     const status = filter === 'all' ? undefined : filter;
     fetchReceivedRequests(status);
-  };
+  }, [filter, fetchReceivedRequests]);
 
   useEffect(() => {
     loadRequests();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter]);
+  }, [loadRequests]);
 
-  const handleConfirm = (request: MedicationRequest) => {
-    Alert.alert(
-      'Confirmar Solicitação',
-      `Confirmar a entrega do medicamento "${request.medication_offering?.drug?.product_name}" para ${request.receptor?.name}?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Confirmar',
-          onPress: async () => {
-            try {
-              await confirmRequest(request.id);
-              toast.success('Solicitação confirmada com sucesso!');
-            } catch (error: any) {
-              Alert.alert('Erro', error.message || 'Não foi possível confirmar a solicitação.');
-            }
+  const handleConfirm = useCallback(
+    (request: MedicationRequest) => {
+      Alert.alert(
+        'Confirmar Solicitação',
+        `Confirmar a entrega do medicamento "${request.medication_offering?.drug?.product_name}" para ${request.receptor?.name}?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Confirmar',
+            onPress: async () => {
+              try {
+                await confirmRequest(request.id);
+                toast.success('Solicitação confirmada com sucesso!');
+              } catch (error: any) {
+                Alert.alert('Erro', error.message || 'Não foi possível confirmar a solicitação.');
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [confirmRequest]
+  );
 
-  const handleReject = (request: MedicationRequest) => {
-    Alert.alert(
-      'Recusar Solicitação',
-      `Recusar a solicitação do medicamento "${request.medication_offering?.drug?.product_name}" de ${request.receptor?.name}?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Recusar',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await rejectRequest(request.id);
-              toast.success('Solicitação recusada.');
-            } catch (error: any) {
-              Alert.alert('Erro', error.message || 'Não foi possível recusar a solicitação.');
-            }
+  const handleReject = useCallback(
+    (request: MedicationRequest) => {
+      Alert.alert(
+        'Recusar Solicitação',
+        `Recusar a solicitação do medicamento "${request.medication_offering?.drug?.product_name}" de ${request.receptor?.name}?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Recusar',
+            style: 'destructive',
+            onPress: async () => {
+              try {
+                await rejectRequest(request.id);
+                toast.success('Solicitação recusada.');
+              } catch (error: any) {
+                Alert.alert('Erro', error.message || 'Não foi possível recusar a solicitação.');
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [rejectRequest]
+  );
 
-  const renderItem = ({ item }: { item: MedicationRequest }) => (
-    <MedicationRequestCard
-      request={item}
-      variant="doctor"
-      onConfirm={() => handleConfirm(item)}
-      onReject={() => handleReject(item)}
-    />
+  const renderItem = useCallback(
+    ({ item }: { item: MedicationRequest }) => (
+      <MedicationRequestCard
+        request={item}
+        variant="doctor"
+        onConfirm={() => handleConfirm(item)}
+        onReject={() => handleReject(item)}
+      />
+    ),
+    [handleConfirm, handleReject]
   );
 
   const renderEmpty = () => {

--- a/mobile/app/(auth)/receptor/(tabs)/appointments.tsx
+++ b/mobile/app/(auth)/receptor/(tabs)/appointments.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -31,78 +31,89 @@ export default function ReceptorAppointmentsScreen() {
 
   const [filter, setFilter] = useState<FilterOption>('proposed');
 
-  const loadAppointments = () => {
+  const loadAppointments = useCallback(() => {
     const status = filter === 'all' ? undefined : filter;
     fetchMyAppointments(status);
-  };
+  }, [filter, fetchMyAppointments]);
 
   useEffect(() => {
     loadAppointments();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter]);
+  }, [loadAppointments]);
 
-  const handleAccept = (appointment: MedicationAppointment) => {
-    Alert.alert(
-      'Aceitar Proposta',
-      `Aceitar o agendamento para ${new Date(appointment.scheduled_date).toLocaleDateString('pt-BR')} às ${appointment.scheduled_time.substring(0, 5)}?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Aceitar',
-          onPress: async () => {
-            try {
-              await acceptAppointment(appointment.id, false);
-              toast.success('Agendamento confirmado!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível aceitar o agendamento.');
-            }
+  const handleAccept = useCallback(
+    (appointment: MedicationAppointment) => {
+      Alert.alert(
+        'Aceitar Proposta',
+        `Aceitar o agendamento para ${new Date(appointment.scheduled_date).toLocaleDateString('pt-BR')} às ${appointment.scheduled_time.substring(0, 5)}?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Aceitar',
+            onPress: async () => {
+              try {
+                await acceptAppointment(appointment.id, false);
+                toast.success('Agendamento confirmado!');
+              } catch (err: any) {
+                Alert.alert('Erro', err.message || 'Não foi possível aceitar o agendamento.');
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [acceptAppointment]
+  );
 
-  const handleCounterPropose = async (
-    appointmentId: number,
-    data: { scheduled_date: string; scheduled_time: string; address_id?: number }
-  ) => {
-    try {
-      await counterProposeAppointment(appointmentId, data, false);
-      toast.success('Contraproposta enviada!');
-    } catch (err: any) {
-      throw err; // Let the modal handle the error display
-    }
-  };
+  const handleCounterPropose = useCallback(
+    async (
+      appointmentId: number,
+      data: { scheduled_date: string; scheduled_time: string; address_id?: number }
+    ) => {
+      try {
+        await counterProposeAppointment(appointmentId, data, false);
+        toast.success('Contraproposta enviada!');
+      } catch (err: any) {
+        throw err; // Let the modal handle the error display
+      }
+    },
+    [counterProposeAppointment]
+  );
 
-  const handleConfirmDelivery = (appointment: MedicationAppointment) => {
-    Alert.alert(
-      'Confirmar Recebimento',
-      `Confirmar que você recebeu o medicamento "${appointment.medication_request?.medication_offering?.drug?.product_name}"?`,
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Confirmar',
-          onPress: async () => {
-            try {
-              await confirmDeliveryReceptor(appointment.id);
-              toast.success('Recebimento confirmado com sucesso!');
-            } catch (err: any) {
-              Alert.alert('Erro', err.message || 'Não foi possível confirmar o recebimento.');
-            }
+  const handleConfirmDelivery = useCallback(
+    (appointment: MedicationAppointment) => {
+      Alert.alert(
+        'Confirmar Recebimento',
+        `Confirmar que você recebeu o medicamento "${appointment.medication_request?.medication_offering?.drug?.product_name}"?`,
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          {
+            text: 'Confirmar',
+            onPress: async () => {
+              try {
+                await confirmDeliveryReceptor(appointment.id);
+                toast.success('Recebimento confirmado com sucesso!');
+              } catch (err: any) {
+                Alert.alert('Erro', err.message || 'Não foi possível confirmar o recebimento.');
+              }
+            },
           },
-        },
-      ]
-    );
-  };
+        ]
+      );
+    },
+    [confirmDeliveryReceptor]
+  );
 
-  const renderItem = ({ item }: { item: MedicationAppointment }) => (
-    <MedicationAppointmentCard
-      appointment={item}
-      variant="receptor"
-      onConfirmDelivery={() => handleConfirmDelivery(item)}
-      onAccept={() => handleAccept(item)}
-      onCounterPropose={(data) => handleCounterPropose(item.id, data)}
-    />
+  const renderItem = useCallback(
+    ({ item }: { item: MedicationAppointment }) => (
+      <MedicationAppointmentCard
+        appointment={item}
+        variant="receptor"
+        onConfirmDelivery={() => handleConfirmDelivery(item)}
+        onAccept={() => handleAccept(item)}
+        onCounterPropose={(data) => handleCounterPropose(item.id, data)}
+      />
+    ),
+    [handleConfirmDelivery, handleAccept, handleCounterPropose]
   );
 
   const renderEmpty = () => {

--- a/mobile/components/MedicationOfferingCard/index.tsx
+++ b/mobile/components/MedicationOfferingCard/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, useMemo } from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { MedicationOffering } from '@/types/medicationOffering';
 import { Colors } from '@/constants/Colors';
@@ -11,12 +11,15 @@ interface MedicationOfferingCardProps {
   onDelete: () => void;
 }
 
-export function MedicationOfferingCard({
+export const MedicationOfferingCard = memo(function MedicationOfferingCard({
   offering,
   onEdit,
   onDelete,
 }: MedicationOfferingCardProps) {
-  const isExpired = new Date(offering.expires_at) < new Date();
+  const isExpired = useMemo(
+    () => new Date(offering.expires_at) < new Date(),
+    [offering.expires_at]
+  );
 
   return (
     <View style={[styles.card, isExpired && styles.expiredCard]}>
@@ -58,7 +61,7 @@ export function MedicationOfferingCard({
       </View>
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   card: {

--- a/mobile/components/MedicationRequestCard/index.tsx
+++ b/mobile/components/MedicationRequestCard/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, useMemo } from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { MedicationRequest } from '@/types/medicationRequest';
 import { RequestStatusBadge } from '@/components/RequestStatusBadge';
@@ -15,7 +15,7 @@ interface MedicationRequestCardProps {
   hasAppointment?: boolean;
 }
 
-export function MedicationRequestCard({
+export const MedicationRequestCard = memo(function MedicationRequestCard({
   request,
   variant,
   onConfirm,
@@ -24,7 +24,7 @@ export function MedicationRequestCard({
   hasAppointment = false,
 }: MedicationRequestCardProps) {
   const offering = request.medication_offering;
-  const isPending = request.status === 'pending';
+  const isPending = useMemo(() => request.status === 'pending', [request.status]);
 
   return (
     <View style={styles.card}>
@@ -111,7 +111,7 @@ export function MedicationRequestCard({
       )}
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   card: {


### PR DESCRIPTION
## Descrição

Resolve #101 — adiciona memoization em componentes de lista para eliminar re-renders desnecessários.

## Mudanças

### Componentes — `React.memo`

| Componente | Antes | Depois |
|---|---|---|
| `MedicationAppointmentCard` | já tinha `memo` | mantido |
| `MedicationOfferingCard` | função simples | `memo` + `useMemo` para `isExpired` |
| `MedicationRequestCard` | função simples | `memo` + `useMemo` para `isPending` |

### Screens — `useCallback`

**`medication-offerings/index.tsx`**
- `handleEdit`, `handleDelete`, `renderOffering` → `useCallback`

**`medication-requests/index.tsx`**
- `loadRequests`, `handleConfirm`, `handleReject`, `renderItem` → `useCallback`
- Removido `eslint-disable-next-line react-hooks/exhaustive-deps`

**`medication-appointments/index.tsx`**
- `loadAppointments`, `handleAccept`, `handleCounterPropose`, `handleConfirmDelivery`, `renderItem` → `useCallback`
- Removido `eslint-disable-next-line react-hooks/exhaustive-deps`

**`receptor/(tabs)/appointments.tsx`**
- `loadAppointments`, `handleAccept`, `handleCounterPropose`, `handleConfirmDelivery`, `renderItem` → `useCallback`
- Removido `eslint-disable-next-line react-hooks/exhaustive-deps`

## Checklist
- [x] `MedicationOfferingCard` com `React.memo`
- [x] `MedicationRequestCard` com `React.memo`
- [x] Cálculos derivados com `useMemo`
- [x] Funções com `useCallback` nas screens pai
- [x] ESLint sem erros
- [x] TypeScript sem erros
- [x] 195 testes passando