### PR TITLE
ci: add GitHub Actions workflows for web and mobile with Dependabot (#100)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      laravel:
+        patterns:
+          - 'laravel/*'
+          - 'illuminate/*'
+
+  - package-ecosystem: npm
+    directory: /mobile
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      expo:
+        patterns:
+          - 'expo*'
+          - '@expo/*'
+      react-native:
+        patterns:
+          - 'react-native*'
+          - '@react-native/*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -1,0 +1,45 @@
+name: CI — Mobile (React Native)
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/ci-mobile.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/ci-mobile.yml'
+
+jobs:
+  ci:
+    name: ESLint · TypeScript · Jest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        working-directory: mobile
+        run: npm ci
+
+      - name: Run ESLint
+        working-directory: mobile
+        run: npm run lint
+
+      - name: Check TypeScript types
+        working-directory: mobile
+        run: npm run check-types
+
+      - name: Run Jest tests
+        working-directory: mobile
+        run: npm test -- --passWithNoTests --ci

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,0 +1,78 @@
+name: CI — Web (Laravel)
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'web/**'
+      - '.github/workflows/ci-web.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'web/**'
+      - '.github/workflows/ci-web.yml'
+
+jobs:
+  ci:
+    name: PHPStan · Pint · Pest
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: doafarma_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.5
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: pdo, pdo_sqlite, pdo_pgsql
+          coverage: none
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: web/vendor
+          key: composer-${{ hashFiles('web/composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install dependencies
+        working-directory: web
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Copy .env
+        working-directory: web
+        run: cp .env.example .env
+
+      - name: Generate key
+        working-directory: web
+        run: php artisan key:generate
+
+      - name: Run PHPStan
+        working-directory: web
+        run: composer analyse --no-interaction
+
+      - name: Run Pint (check only)
+        working-directory: web
+        run: ./vendor/bin/pint --test
+
+      - name: Run Pest
+        working-directory: web
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ':memory:'
+        run: composer tp

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DoaFarma
 
+[![CI — Web](https://github.com/jcfurtado86/doafarma/actions/workflows/ci-web.yml/badge.svg)](https://github.com/jcfurtado86/doafarma/actions/workflows/ci-web.yml)
+[![CI — Mobile](https://github.com/jcfurtado86/doafarma/actions/workflows/ci-mobile.yml/badge.svg)](https://github.com/jcfurtado86/doafarma/actions/workflows/ci-mobile.yml)
+
+
 Plataforma de doacao de medicamentos que conecta medicos (doadores) com receptores. O projeto consiste em um monorepo com duas aplicacoes principais:
 
 - **`web/`** — Backend API + Painel Admin (Laravel 12 + Filament 5)


### PR DESCRIPTION
## Descrição

Resolve #100 — implementa CI/CD com GitHub Actions para validar PRs automaticamente.

## Mudanças

### `.github/workflows/ci-web.yml`
- Trigger: push/PR em `main` e `develop` com mudanças em `web/`
- Jobs: **PHPStan** → **Pint** (check only) → **Pest** (SQLite in-memory)
- Serviço PostgreSQL 17 disponível para integração futura
- Cache de `vendor/` via `composer.lock`

### `.github/workflows/ci-mobile.yml`
- Trigger: push/PR em `main` e `develop` com mudanças em `mobile/`
- Jobs: **ESLint** → **TypeScript** (`tsc --noemit`) → **Jest**
- Cache de `node_modules/` via `package-lock.json`

### `.github/dependabot.yml`
- Composer (web): weekly, agrupa pacotes `laravel/*`
- npm (mobile): weekly, agrupa `expo*` e `react-native*`
- GitHub Actions: weekly

### `README.md`
- Badges de status dos workflows adicionados ao topo

## Checklist
- [x] Workflow para backend (PHPStan, Pint, Pest)
- [x] Workflow para mobile (ESLint, TypeScript, Jest)
- [x] Dependabot configurado
- [x] Badge de status no README