### PR TITLE
feat(auth): auto-approve receptors on registration

### DIFF
--- a/web/app/Actions/Auth/CreateReceptorAction.php
+++ b/web/app/Actions/Auth/CreateReceptorAction.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace App\Actions\Auth;
 
+use App\Enums\UserStatus;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -37,6 +38,7 @@ class CreateReceptorAction
             'role'              => 'receptor',
             'phone_number'      => $data['phone_number'],
             'password'          => Hash::make($data['password']),
+            'status'            => UserStatus::Approved,
             'terms_accepted'    => $data['terms_accepted'],
             'terms_accepted_at' => now(),
         ]));

--- a/web/tests/Feature/Auth/RegisterReceptorTest.php
+++ b/web/tests/Feature/Auth/RegisterReceptorTest.php
@@ -496,6 +496,51 @@ describe('Receptor Registration - Security Tests', function (): void {
     });
 });
 
+describe('Receptor Registration - Auto Approval', function (): void {
+    it('should create receptor with status approved', function (): void {
+        postJson(route('receptor.register'), [
+            'name'                  => 'Auto Approved',
+            'email'                 => 'approved@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ])->assertCreated();
+
+        $user = User::whereEmail('approved@example.com')->first();
+        expect($user->status->value)->toBe('approved');
+
+        assertDatabaseHas('users', [
+            'email'  => 'approved@example.com',
+            'status' => 'approved',
+        ]);
+    });
+
+    it('should allow receptor to access protected routes immediately after registration', function (): void {
+        $response = postJson(route('receptor.register'), [
+            'name'                  => 'Immediate Access',
+            'email'                 => 'immediate@example.com',
+            'cpf'                   => '529.982.247-25',
+            'phone_number'          => '(11) 98765-4321',
+            'password'              => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'device_name'           => 'Test Device',
+            'terms_accepted'        => true,
+        ]);
+
+        $response->assertCreated();
+
+        $token = $response->json('data.token');
+
+        $protectedResponse = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/api/v1/drugs/search?query=test');
+
+        $protectedResponse->assertOk();
+    });
+});
+
 describe('Receptor Registration - CPF Validation Algorithm', function (): void {
     it('should accept valid CPF: 529.982.247-25', function (): void {
         postJson(route('receptor.register'), [


### PR DESCRIPTION
## Summary
- Receptors are now auto-approved (`status = approved`) on registration, removing the need for manual admin approval
- Doctors continue requiring admin approval (`status = pending`)
- Receptors can access protected routes immediately after registration

Closes #148

## Test plan
- [x] Receptor is created with `status = approved` in the database
- [x] Receptor can access protected routes immediately after registration
- [x] All existing 30 registration tests continue passing