### PR TITLE
feat(auth): add password reset API endpoints (#150)

### DIFF
--- a/web/app/Actions/Auth/ResetPasswordAction.php
+++ b/web/app/Actions/Auth/ResetPasswordAction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\Auth;
+
+use App\Http\Requests\Api\V1\Auth\ResetPasswordRequest;
+use App\Models\User;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+
+class ResetPasswordAction
+{
+    /**
+     * Execute the password reset action.
+     *
+     * @param  ResetPasswordRequest  $request
+     * @return string The password broker status
+     */
+    public function execute(ResetPasswordRequest $request): string
+    {
+        /** @var string $status */
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function (User $user) use ($request): void {
+                $user->forceFill([
+                    'password'       => Hash::make($request->string('password')->toString()),
+                    'remember_token' => Str::random(60),
+                ])->save();
+
+                $user->tokens()->delete();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        return $status;
+    }
+}

--- a/web/app/Actions/Auth/SendPasswordResetAction.php
+++ b/web/app/Actions/Auth/SendPasswordResetAction.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Actions\Auth;
+
+use App\Http\Requests\Api\V1\Auth\ForgotPasswordRequest;
+use Illuminate\Support\Facades\Password;
+
+class SendPasswordResetAction
+{
+    /**
+     * Send a password reset link to the given email.
+     *
+     * @param  ForgotPasswordRequest  $request
+     */
+    public function execute(ForgotPasswordRequest $request): void
+    {
+        Password::sendResetLink($request->only('email'));
+    }
+}

--- a/web/app/Http/Controllers/Api/V1/Auth/ForgotPasswordController.php
+++ b/web/app/Http/Controllers/Api/V1/Auth/ForgotPasswordController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\SendPasswordResetAction;
+use App\Http\Requests\Api\V1\Auth\ForgotPasswordRequest;
+use Illuminate\Http\JsonResponse;
+
+class ForgotPasswordController
+{
+    public function __invoke(ForgotPasswordRequest $request, SendPasswordResetAction $action): JsonResponse
+    {
+        $action->execute($request);
+
+        return response()->json([
+            'message' => 'If an account with that email exists, we have sent a password reset link.',
+        ]);
+    }
+}

--- a/web/app/Http/Controllers/Api/V1/Auth/ResetPasswordController.php
+++ b/web/app/Http/Controllers/Api/V1/Auth/ResetPasswordController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Actions\Auth\ResetPasswordAction;
+use App\Http\Requests\Api\V1\Auth\ResetPasswordRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+
+class ResetPasswordController
+{
+    /**
+     * @throws ValidationException
+     */
+    public function __invoke(ResetPasswordRequest $request, ResetPasswordAction $action): JsonResponse
+    {
+        $status = $action->execute($request);
+
+        if ($status !== Password::PASSWORD_RESET) {
+            throw ValidationException::withMessages([
+                'email' => [__($status)],
+            ]);
+        }
+
+        return response()->json([
+            'message' => 'Your password has been reset successfully.',
+        ]);
+    }
+}

--- a/web/app/Http/Requests/Api/V1/Auth/ForgotPasswordRequest.php
+++ b/web/app/Http/Requests/Api/V1/Auth/ForgotPasswordRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Requests\Api\V1\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Override;
+
+class ForgotPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email', 'lowercase'],
+        ];
+    }
+
+    /**
+     * Get custom error messages for validation rules.
+     *
+     * @return array<string, string>
+     */
+    #[Override]
+    public function messages(): array
+    {
+        return [
+            'email.required'  => 'The email field is required.',
+            'email.email'     => 'The email must be a valid email address.',
+            'email.lowercase' => 'The email must be lowercase.',
+        ];
+    }
+}

--- a/web/app/Http/Requests/Api/V1/Auth/ResetPasswordRequest.php
+++ b/web/app/Http/Requests/Api/V1/Auth/ResetPasswordRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Requests\Api\V1\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+use Override;
+
+class ResetPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'token'    => ['required', 'string'],
+            'email'    => ['required', 'string', 'email'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+
+    /**
+     * Get custom error messages for validation rules.
+     *
+     * @return array<string, string>
+     */
+    #[Override]
+    public function messages(): array
+    {
+        return [
+            'token.required'     => 'The reset token is required.',
+            'email.required'     => 'The email field is required.',
+            'email.email'        => 'The email must be a valid email address.',
+            'password.required'  => 'The password field is required.',
+            'password.confirmed' => 'The password confirmation does not match.',
+        ];
+    }
+}

--- a/web/bootstrap/app.php
+++ b/web/bootstrap/app.php
@@ -29,13 +29,16 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->render(function (ThrottleRequestsException $e, $request) {
             if ($request->wantsJson()) {
-                $isLoginRoute = $request->routeIs('api.v1.auth.login');
+                $isLoginRoute         = $request->routeIs('api.v1.auth.login');
+                $isPasswordResetRoute = $request->routeIs('api.v1.auth.forgot-password', 'api.v1.auth.reset-password');
 
-                $message = $isLoginRoute
-                    ? 'Too many login attempts. Please try again later.'
-                    : 'Too many requests. Please try again later.';
+                $message = match (true) {
+                    $isLoginRoute         => 'Too many login attempts. Please try again later.',
+                    $isPasswordResetRoute => 'Too many password reset requests. Please try again later.',
+                    default               => 'Too many requests. Please try again later.',
+                };
 
-                $errorKey = $isLoginRoute ? 'email' : 'rate_limit';
+                $errorKey = ($isLoginRoute || $isPasswordResetRoute) ? 'email' : 'rate_limit';
 
                 return response()->json([
                     'message' => $message,

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -38,6 +38,14 @@ Route::prefix('v1')->group(function (): void {
         Route::post('logout', Auth\LogoutController::class)
             ->middleware(['auth:sanctum', 'abilities:access'])
             ->name('api.v1.auth.logout');
+
+        Route::post('forgot-password', Auth\ForgotPasswordController::class)
+            ->middleware(['guest', 'throttle:3,1'])
+            ->name('api.v1.auth.forgot-password');
+
+        Route::post('reset-password', Auth\ResetPasswordController::class)
+            ->middleware(['guest', 'throttle:3,1'])
+            ->name('api.v1.auth.reset-password');
     });
 
     // Routes that require authentication, approval, AND access token ability

--- a/web/tests/Feature/Api/V1/Auth/ForgotPasswordTest.php
+++ b/web/tests/Feature/Api/V1/Auth/ForgotPasswordTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+
+use function Pest\Laravel\postJson;
+
+it('should send a password reset link for a valid email', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => $user->email,
+    ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'message' => 'If an account with that email exists, we have sent a password reset link.',
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+it('should return 200 even when email does not exist', function (): void {
+    Notification::fake();
+
+    $response = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => 'nonexistent@example.com',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'message' => 'If an account with that email exists, we have sent a password reset link.',
+    ]);
+
+    Notification::assertNothingSent();
+});
+
+it('should require the email field', function (): void {
+    $response = postJson(route('api.v1.auth.forgot-password'), []);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['email']);
+});
+
+it('should require a valid email format', function (): void {
+    $response = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => 'invalid-email',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['email']);
+});
+
+it('should rate limit after 3 requests per minute', function (): void {
+    for ($i = 0; $i < 3; $i++) {
+        postJson(route('api.v1.auth.forgot-password'), [
+            'email' => "user{$i}@example.com",
+        ]);
+    }
+
+    $response = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => 'another@example.com',
+    ]);
+
+    $response->assertStatus(429);
+    $response->assertJson([
+        'message' => 'Too many password reset requests. Please try again later.',
+        'errors'  => [
+            'email' => ['Too many password reset requests. Please try again later.'],
+        ],
+    ]);
+    $response->assertHeader('Retry-After');
+});
+
+it('should still return 200 when broker throttles the same email', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $firstResponse = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => $user->email,
+    ]);
+
+    $firstResponse->assertOk();
+
+    $secondResponse = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => $user->email,
+    ]);
+
+    $secondResponse->assertOk();
+    $secondResponse->assertJson([
+        'message' => 'If an account with that email exists, we have sent a password reset link.',
+    ]);
+});
+
+it('should normalize uppercase email', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create([
+        'email' => 'user@example.com',
+    ]);
+
+    $response = postJson(route('api.v1.auth.forgot-password'), [
+        'email' => 'USER@EXAMPLE.COM',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['email']);
+});

--- a/web/tests/Feature/Api/V1/Auth/ResetPasswordTest.php
+++ b/web/tests/Feature/Api/V1/Auth/ResetPasswordTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+
+use function Pest\Laravel\postJson;
+
+it('should reset password with a valid token', function (): void {
+    $user  = User::factory()->create();
+    $token = Password::createToken($user);
+
+    $response = postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'message' => 'Your password has been reset successfully.',
+    ]);
+
+    $user->refresh();
+    expect(Hash::check('new-password-123', $user->password))->toBeTrue();
+});
+
+it('should allow login with new password after reset', function (): void {
+    $user  = User::factory()->create();
+    $token = Password::createToken($user);
+
+    postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ]);
+
+    $loginResponse = postJson(route('api.v1.auth.login'), [
+        'email'    => $user->email,
+        'password' => 'new-password-123',
+    ]);
+
+    $loginResponse->assertSuccessful();
+});
+
+it('should revoke all existing sanctum tokens after reset', function (): void {
+    $user = User::factory()->create();
+
+    $user->createToken('device:access', ['access']);
+    $user->createToken('device:refresh', ['refresh']);
+    expect($user->tokens()->count())->toBe(2);
+
+    $token = Password::createToken($user);
+
+    postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ])->assertOk();
+
+    expect($user->tokens()->count())->toBe(0);
+});
+
+it('should reject an invalid token', function (): void {
+    $user = User::factory()->create();
+
+    $response = postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => 'invalid-token',
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['email']);
+});
+
+it('should reject an expired token', function (): void {
+    $user  = User::factory()->create();
+    $token = Password::createToken($user);
+
+    $this->travel(61)->minutes();
+
+    $response = postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['email']);
+});
+
+it('should reject when email does not match the token', function (): void {
+    $user  = User::factory()->create();
+    $other = User::factory()->create();
+    $token = Password::createToken($user);
+
+    $response = postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $other->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['email']);
+});
+
+it('should reject when password confirmation does not match', function (): void {
+    $user  = User::factory()->create();
+    $token = Password::createToken($user);
+
+    $response = postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'different-password',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['password']);
+});
+
+it('should require all fields', function (): void {
+    $response = postJson(route('api.v1.auth.reset-password'), []);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['token', 'email', 'password']);
+});
+
+it('should rate limit after 3 requests per minute', function (): void {
+    $user  = User::factory()->create();
+    $token = Password::createToken($user);
+
+    for ($i = 0; $i < 3; $i++) {
+        postJson(route('api.v1.auth.reset-password'), [
+            'token'                 => 'invalid-token',
+            'email'                 => $user->email,
+            'password'              => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+    }
+
+    $response = postJson(route('api.v1.auth.reset-password'), [
+        'token'                 => $token,
+        'email'                 => $user->email,
+        'password'              => 'new-password-123',
+        'password_confirmation' => 'new-password-123',
+    ]);
+
+    $response->assertStatus(429);
+    $response->assertJson([
+        'message' => 'Too many password reset requests. Please try again later.',
+        'errors'  => [
+            'email' => ['Too many password reset requests. Please try again later.'],
+        ],
+    ]);
+});

--- a/web/tests/Feature/Security/RateLimitingTest.php
+++ b/web/tests/Feature/Security/RateLimitingTest.php
@@ -402,6 +402,149 @@ describe('Rate Limiting - Login Endpoint', function (): void {
     });
 });
 
+describe('Rate Limiting - Password Reset Endpoints', function (): void {
+    describe('Forgot Password', function (): void {
+        it('should allow up to 3 requests per minute', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                $response = postJson(route('api.v1.auth.forgot-password'), [
+                    'email' => "user{$i}@example.com",
+                ]);
+                expect($response->status())->not->toBe(429);
+            }
+        });
+
+        it('should return 429 after 3 requests', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                postJson(route('api.v1.auth.forgot-password'), [
+                    'email' => "user{$i}@example.com",
+                ]);
+            }
+
+            $response = postJson(route('api.v1.auth.forgot-password'), [
+                'email' => 'another@example.com',
+            ]);
+
+            $response->assertStatus(429);
+        });
+
+        it('should include Retry-After header when rate limited', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                postJson(route('api.v1.auth.forgot-password'), [
+                    'email' => "user{$i}@example.com",
+                ]);
+            }
+
+            $response = postJson(route('api.v1.auth.forgot-password'), [
+                'email' => 'another@example.com',
+            ]);
+
+            $response->assertStatus(429);
+            $response->assertHeader('Retry-After');
+        });
+
+        it('should return password-reset-specific JSON error message when rate limited', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                postJson(route('api.v1.auth.forgot-password'), [
+                    'email' => "user{$i}@example.com",
+                ]);
+            }
+
+            $response = postJson(route('api.v1.auth.forgot-password'), [
+                'email' => 'another@example.com',
+            ]);
+
+            $response->assertStatus(429);
+            $response->assertJson([
+                'message' => 'Too many password reset requests. Please try again later.',
+                'errors'  => [
+                    'email' => ['Too many password reset requests. Please try again later.'],
+                ],
+            ]);
+        });
+    });
+
+    describe('Reset Password', function (): void {
+        it('should allow up to 3 requests per minute', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                $response = postJson(route('api.v1.auth.reset-password'), [
+                    'token'                 => 'fake-token',
+                    'email'                 => "user{$i}@example.com",
+                    'password'              => 'new-password-123',
+                    'password_confirmation' => 'new-password-123',
+                ]);
+                expect($response->status())->not->toBe(429);
+            }
+        });
+
+        it('should return 429 after 3 requests', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                postJson(route('api.v1.auth.reset-password'), [
+                    'token'                 => 'fake-token',
+                    'email'                 => "user{$i}@example.com",
+                    'password'              => 'new-password-123',
+                    'password_confirmation' => 'new-password-123',
+                ]);
+            }
+
+            $response = postJson(route('api.v1.auth.reset-password'), [
+                'token'                 => 'fake-token',
+                'email'                 => 'another@example.com',
+                'password'              => 'new-password-123',
+                'password_confirmation' => 'new-password-123',
+            ]);
+
+            $response->assertStatus(429);
+        });
+
+        it('should include Retry-After header when rate limited', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                postJson(route('api.v1.auth.reset-password'), [
+                    'token'                 => 'fake-token',
+                    'email'                 => "user{$i}@example.com",
+                    'password'              => 'new-password-123',
+                    'password_confirmation' => 'new-password-123',
+                ]);
+            }
+
+            $response = postJson(route('api.v1.auth.reset-password'), [
+                'token'                 => 'fake-token',
+                'email'                 => 'another@example.com',
+                'password'              => 'new-password-123',
+                'password_confirmation' => 'new-password-123',
+            ]);
+
+            $response->assertStatus(429);
+            $response->assertHeader('Retry-After');
+        });
+
+        it('should return password-reset-specific JSON error message when rate limited', function (): void {
+            for ($i = 0; $i < 3; $i++) {
+                postJson(route('api.v1.auth.reset-password'), [
+                    'token'                 => 'fake-token',
+                    'email'                 => "user{$i}@example.com",
+                    'password'              => 'new-password-123',
+                    'password_confirmation' => 'new-password-123',
+                ]);
+            }
+
+            $response = postJson(route('api.v1.auth.reset-password'), [
+                'token'                 => 'fake-token',
+                'email'                 => 'another@example.com',
+                'password'              => 'new-password-123',
+                'password_confirmation' => 'new-password-123',
+            ]);
+
+            $response->assertStatus(429);
+            $response->assertJson([
+                'message' => 'Too many password reset requests. Please try again later.',
+                'errors'  => [
+                    'email' => ['Too many password reset requests. Please try again later.'],
+                ],
+            ]);
+        });
+    });
+});
+
 describe('Rate Limiting - Refresh Endpoint', function (): void {
     it('should allow up to 10 refresh attempts per minute', function (): void {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/auth/forgot-password` endpoint that sends reset link without revealing email existence
- Add `POST /api/v1/auth/reset-password` endpoint that resets password, revokes all Sanctum tokens
- Rate limiting (3/min) with custom error messages on both endpoints
- Follows existing Controller → Action → FormRequest pattern

## Changes

| File | Action |
|------|--------|
| `ForgotPasswordRequest` | Create — email validation (required, email, lowercase) |
| `SendPasswordResetAction` | Create — calls Password::sendResetLink, swallows status |
| `ForgotPasswordController` | Create — always returns 200 with generic message |
| `ResetPasswordRequest` | Create — token, email, password + confirmation validation |
| `ResetPasswordAction` | Create — resets password, revokes tokens, fires event |
| `ResetPasswordController` | Create — 200 on success, ValidationException on failure |
| `routes/api.php` | Modify — register both routes with guest + throttle:3,1 |
| `bootstrap/app.php` | Modify — custom throttle message for password reset routes |

## Test plan

- [x] 7 tests for forgot-password (happy path, non-existent email, validation, rate limiting, broker throttle, email normalization)
- [x] 8 tests for reset-password (happy path, new login, token revocation, invalid/expired token, email mismatch, confirmation, required fields, rate limiting)
- [x] 8 rate limiting security tests for both endpoints
- [x] PHPStan level 6 — no errors
- [x] Pint — formatted
- [x] Full test suite — 568 passing

Closes #150