### PR TITLE
feat(auth)!: replace registration single token with dual-token pair

### DIFF
--- a/mobile/services/doctorService.ts
+++ b/mobile/services/doctorService.ts
@@ -2,10 +2,31 @@ import { apiClient } from './api';
 import { DoctorRegistrationFormData } from '@/stores/doctorRegistrationFormStore';
 import { logger } from '@/utils/logger';
 
+export interface DoctorRegistrationResponse {
+  data: {
+    user: {
+      id: number;
+      name: string;
+      email: string;
+      phone_number: string;
+      role: 'doctor' | 'receptor';
+      status: 'pending' | 'approved' | 'rejected';
+    };
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    refresh_expires_in: number;
+  };
+  message: string;
+}
+
 export const doctorService = {
-  register: async (doctorData: DoctorRegistrationFormData) => {
+  register: async (doctorData: DoctorRegistrationFormData): Promise<DoctorRegistrationResponse> => {
     try {
-      const response = await apiClient.post('/register/doctor', doctorData);
+      const response = await apiClient.post<DoctorRegistrationResponse>(
+        '/register/doctor',
+        doctorData
+      );
       return response.data;
     } catch (error) {
       logger.error('Erro ao registrar médico:', error);

--- a/mobile/services/receptorService.ts
+++ b/mobile/services/receptorService.ts
@@ -23,8 +23,12 @@ export interface ReceptorRegistrationResponse {
       role: 'doctor' | 'receptor';
       status: 'pending' | 'approved' | 'rejected';
     };
-    token: string;
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    refresh_expires_in: number;
   };
+  message: string;
 }
 
 export interface ApiValidationError {

--- a/mobile/stores/doctorRegistrationFormStore.ts
+++ b/mobile/stores/doctorRegistrationFormStore.ts
@@ -110,9 +110,9 @@ export const useDoctorRegistrationFormStore = create<DoctorRegistrationFormStore
 
       const responseData = await doctorService.register(formData);
 
-      const { user, token } = responseData.data;
+      const { user, access_token, refresh_token, expires_in } = responseData.data;
 
-      await useAuthStore.getState().saveSession(user, token);
+      await useAuthStore.getState().saveSession(user, access_token, refresh_token, expires_in);
 
       set({ isLoading: false });
       return true;

--- a/mobile/stores/receptorRegistrationStore.ts
+++ b/mobile/stores/receptorRegistrationStore.ts
@@ -78,9 +78,9 @@ export const useReceptorRegistrationStore = create<ReceptorRegistrationFormStore
 
       const response = await receptorService.register(registrationData);
 
-      const { user, token } = response.data;
+      const { user, access_token, refresh_token, expires_in } = response.data;
 
-      await useAuthStore.getState().saveSession(user, token);
+      await useAuthStore.getState().saveSession(user, access_token, refresh_token, expires_in);
 
       set({ isLoading: false });
       return true;

--- a/web/app/Http/Controllers/Auth/DoctorRegistrationController.php
+++ b/web/app/Http/Controllers/Auth/DoctorRegistrationController.php
@@ -5,9 +5,10 @@ declare(strict_types = 1);
 namespace App\Http\Controllers\Auth;
 
 use App\Actions\Auth\CreateDoctorAction;
+use App\Actions\Auth\CreateTokenPairAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\DoctorRegistrationRequest;
-use App\Http\Resources\UserResource;
+use App\Http\Resources\Api\V1\RegistrationResource;
 use Illuminate\Http\JsonResponse;
 
 class DoctorRegistrationController extends Controller
@@ -20,7 +21,7 @@ class DoctorRegistrationController extends Controller
     /**
      * Handle the incoming request.
      */
-    public function __invoke(DoctorRegistrationRequest $request): JsonResponse
+    public function __invoke(DoctorRegistrationRequest $request, CreateTokenPairAction $createTokenPairAction): JsonResponse
     {
         $user = $this->createDoctorAction->execute([
             'name'           => $request->validated('name'),
@@ -35,13 +36,10 @@ class DoctorRegistrationController extends Controller
 
         $user->load('doctor');
 
-        $token = $user->createToken($request->validated('device_name'))->plainTextToken;
+        $tokens = $createTokenPairAction->execute($user, $request->validated('device_name'));
 
-        return response()->json([
-            'data' => [
-                'user'  => new UserResource($user),
-                'token' => $token,
-            ],
-        ], JsonResponse::HTTP_CREATED);
+        return (new RegistrationResource(array_merge(['user' => $user], $tokens)))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
     }
 }

--- a/web/app/Http/Controllers/Auth/ReceptorRegistrationController.php
+++ b/web/app/Http/Controllers/Auth/ReceptorRegistrationController.php
@@ -5,9 +5,10 @@ declare(strict_types = 1);
 namespace App\Http\Controllers\Auth;
 
 use App\Actions\Auth\CreateReceptorAction;
+use App\Actions\Auth\CreateTokenPairAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\ReceptorRegistrationRequest;
-use App\Http\Resources\UserResource;
+use App\Http\Resources\Api\V1\RegistrationResource;
 use Illuminate\Http\JsonResponse;
 
 class ReceptorRegistrationController extends Controller
@@ -20,7 +21,7 @@ class ReceptorRegistrationController extends Controller
     /**
      * Handle the incoming request.
      */
-    public function __invoke(ReceptorRegistrationRequest $request): JsonResponse
+    public function __invoke(ReceptorRegistrationRequest $request, CreateTokenPairAction $createTokenPairAction): JsonResponse
     {
         $user = $this->createReceptorAction->execute([
             'name'           => $request->validated('name'),
@@ -31,13 +32,10 @@ class ReceptorRegistrationController extends Controller
             'terms_accepted' => $request->validated('terms_accepted'),
         ]);
 
-        $token = $user->createToken($request->validated('device_name'))->plainTextToken;
+        $tokens = $createTokenPairAction->execute($user, $request->validated('device_name'));
 
-        return response()->json([
-            'data' => [
-                'user'  => new UserResource($user),
-                'token' => $token,
-            ],
-        ], JsonResponse::HTTP_CREATED);
+        return (new RegistrationResource(array_merge(['user' => $user], $tokens)))
+            ->response()
+            ->setStatusCode(JsonResponse::HTTP_CREATED);
     }
 }

--- a/web/app/Http/Resources/Api/V1/RegistrationResource.php
+++ b/web/app/Http/Resources/Api/V1/RegistrationResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Http\Resources\UserResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Override;
+
+class RegistrationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function toArray(Request $request): array
+    {
+        return [
+            'data' => [
+                'user'               => new UserResource($this->resource['user']),
+                'access_token'       => $this->resource['access_token'],
+                'refresh_token'      => $this->resource['refresh_token'],
+                'expires_in'         => $this->resource['expires_in'],
+                'refresh_expires_in' => $this->resource['refresh_expires_in'],
+            ],
+            'message' => 'Cadastro realizado com sucesso',
+        ];
+    }
+}

--- a/web/tests/Feature/Auth/RegisterReceptorTest.php
+++ b/web/tests/Feature/Auth/RegisterReceptorTest.php
@@ -37,8 +37,12 @@ describe('Receptor Registration - Success Scenarios', function (): void {
         $response->assertJsonStructure([
             'data' => [
                 'user' => ['id', 'name', 'email', 'phone_number', 'role'],
-                'token',
+                'access_token',
+                'refresh_token',
+                'expires_in',
+                'refresh_expires_in',
             ],
+            'message',
         ]);
 
         // Verify user was created in database
@@ -54,7 +58,7 @@ describe('Receptor Registration - Success Scenarios', function (): void {
         assertDatabaseCount('users', 1);
     });
 
-    it('should return a valid Sanctum token upon successful registration', function (): void {
+    it('should return a valid Sanctum token pair upon successful registration', function (): void {
         $response = postJson(route('receptor.register'), [
             'name'                  => 'João Santos',
             'email'                 => 'joao@example.com',
@@ -68,12 +72,11 @@ describe('Receptor Registration - Success Scenarios', function (): void {
 
         $response->assertCreated();
 
-        $token = $response->json('data.token');
+        $token = $response->json('data.access_token');
         expect($token)->not->toBeEmpty();
 
-        // Verify token was created in database
         $user = User::whereEmail('joao@example.com')->first();
-        expect($user->tokens)->toHaveCount(1);
+        expect($user->tokens)->toHaveCount(2);
     });
 
     it('should hash the password correctly', function (): void {
@@ -532,7 +535,7 @@ describe('Receptor Registration - Auto Approval', function (): void {
 
         $response->assertCreated();
 
-        $token = $response->json('data.token');
+        $token = $response->json('data.access_token');
 
         $protectedResponse = $this->withHeader('Authorization', "Bearer {$token}")
             ->getJson('/api/v1/drugs/search?query=test');

--- a/web/tests/Feature/DoctorRegistrationTest.php
+++ b/web/tests/Feature/DoctorRegistrationTest.php
@@ -110,19 +110,22 @@ it('should be able to register a doctor with active CRM', function (): void {
     expect($doctor->crm_verified_at)->not->toBeNull();
 });
 
-it('should return a valid token upon successful registration', function (): void {
+it('should return a valid token pair upon successful registration', function (): void {
     fakeCrmApi();
 
     $response = postJson(route('doctor.register'), validDoctorData());
 
     $response->assertCreated();
-    $response->assertJsonStructure(['data' => ['user', 'token']]);
+    $response->assertJsonStructure([
+        'data' => ['user', 'access_token', 'refresh_token', 'expires_in', 'refresh_expires_in'],
+        'message',
+    ]);
 
-    $token = $response->json('data.token');
+    $token = $response->json('data.access_token');
     expect($token)->not->toBeEmpty();
 
     $user = User::whereEmail('test@example.com')->first();
-    expect($user->tokens)->toHaveCount(1);
+    expect($user->tokens)->toHaveCount(2);
 });
 
 it('should return the correct user data upon successful registration', function (): void {


### PR DESCRIPTION
## Summary

Tokens de registro (doctor e receptor) eram criados com `createToken()->plainTextToken` — sem abilities, sem expiração. Isso é uma inconsistência de segurança: o login usa dual-token (access + refresh) com escopo e TTL, mas o registro gerava um token eterno e sem restrições.

Agora o registro usa o mesmo `CreateTokenPairAction` do login, retornando access_token + refresh_token com expiração adequada.

Closes #154

## Changes

- Criar `RegistrationResource` espelhando o padrão do `LoginResource`
- Injetar `CreateTokenPairAction` nos controllers de registro (doctor e receptor)
- Atualizar response de `{ token }` para `{ access_token, refresh_token, expires_in, refresh_expires_in }`
- Atualizar interfaces e stores do mobile para consumir o novo formato
- Passar `refresh_token` e `expires_in` para `saveSession()` no registro

## How it works

Os controllers agora delegam a criação de tokens para `CreateTokenPairAction` (já existente), que gera um par access/refresh com abilities (`TokenAbility::Access`, `TokenAbility::Refresh`) e expiração configurável via `sanctum.access_token_expiration_hours` / `sanctum.refresh_token_expiration_days`.

O `RegistrationResource` encapsula a resposta no mesmo formato do `LoginResource`, com a mensagem "Cadastro realizado com sucesso".

No mobile, os stores de registro agora passam todos os campos de token para `saveSession()`, que já suportava os parâmetros opcionais `refreshToken` e `expiresIn`.

## Breaking changes

- `POST /register/doctor` e `POST /register/receptor`: campo `token` substituído por `access_token`, `refresh_token`, `expires_in`, `refresh_expires_in`
- Response agora inclui campo `message` no nível raiz

## Test plan

- [x] Backend: 592 testes passando (PHPStan + Pest em cada commit via pre-commit hook)
- [x] Mobile: 217 testes passando (ESLint + TypeScript + Jest via pre-commit hook)
- [ ] Manual: registrar doctor via mobile, verificar tokens no SecureStore
- [ ] Manual: registrar receptor via mobile, verificar expiração do token
